### PR TITLE
fix(client): resolve infinite render loop in RequestDialog

### DIFF
--- a/packages/client/src/components/ui/RequestDialog.tsx
+++ b/packages/client/src/components/ui/RequestDialog.tsx
@@ -62,8 +62,7 @@ function RequestDialog({
       createMovieMutation.reset();
       createTvMutation.reset();
     }
-    // Mutations are stable references from tRPC, safe to include
-  }, [isOpen, createMovieMutation, createTvMutation]);
+  }, [isOpen]);
 
   const toggleServer = (serverId: string) => {
     setServerSelections((prev) => {


### PR DESCRIPTION
Fixes #4

Removed mutation objects from useEffect dependency array to prevent infinite re-render cycle when resetting mutation state.

### Changes
- Removed `createMovieMutation` and `createTvMutation` from useEffect dependencies
- Effect now only triggers on `isOpen` changes

Generated with [Claude Code](https://claude.ai/code)