### PR TITLE
Add comprehensive test suites for requests router and circuit breaker

### DIFF
--- a/packages/server/src/__tests__/routers/requests.test.ts
+++ b/packages/server/src/__tests__/routers/requests.test.ts
@@ -1,0 +1,915 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createMockPrisma } from "../setup.js";
+
+const mockPrisma = createMockPrisma();
+
+// Circuit breaker + settings stores for pipeline orchestrator
+const circuitBreakerStore = new Map<string, any>();
+const settingsStore = new Map<string, any>();
+
+mockPrisma.circuitBreaker = {
+  findUnique: mock(async ({ where }: any) => circuitBreakerStore.get(where.service) || null),
+  create: mock(async ({ data }: any) => {
+    const record = { ...data, createdAt: new Date(), updatedAt: new Date() };
+    circuitBreakerStore.set(data.service, record);
+    return record;
+  }),
+  update: mock(async ({ where, data }: any) => {
+    const record = circuitBreakerStore.get(where.service);
+    if (!record) throw new Error("Not found");
+    const updated = { ...record, ...data };
+    circuitBreakerStore.set(where.service, updated);
+    return updated;
+  }),
+  findMany: mock(async () => Array.from(circuitBreakerStore.values())),
+};
+
+mockPrisma.settings = {
+  findUnique: mock(async ({ where }: any) => settingsStore.get(where.id) || null),
+};
+
+// Add missing findFirst/findMany to pipelineTemplate mock
+const pipelineTemplateStore = mockPrisma._stores.pipelineTemplate;
+mockPrisma.pipelineTemplate.findFirst = mock(async ({ where }: any = {}) => {
+  const values = Array.from(pipelineTemplateStore.values());
+  if (!where) return values[0] || null;
+  return values.find((v: any) => Object.keys(where).every((k) => v[k] === where[k])) || null;
+});
+mockPrisma.pipelineTemplate.findMany = mock(async ({ where }: any = {}) => {
+  const values = Array.from(pipelineTemplateStore.values());
+  if (!where) return values;
+  return values.filter((v: any) => Object.keys(where).every((k) => v[k] === where[k]));
+});
+
+// Add missing findMany to pipelineExecution mock
+const pipelineExecutionStore = mockPrisma._stores.pipelineExecution;
+mockPrisma.pipelineExecution.findMany = mock(async ({ where }: any = {}) => {
+  const values = Array.from(pipelineExecutionStore.values());
+  if (!where) return values;
+  return values.filter((v: any) => Object.keys(where).every((k) => v[k] === where[k]));
+});
+
+// Add missing/enhanced methods to processingItem mock
+const processingItemStore = mockPrisma._stores.processingItem;
+const mediaRequestStore = mockPrisma._stores.mediaRequest;
+
+// Override findUnique to support include: { request }
+mockPrisma.processingItem.findUnique = mock(async ({ where, include }: any) => {
+  const record = processingItemStore.get(where.id);
+  if (!record) return null;
+  if (include?.request) {
+    const request = mediaRequestStore.get(record.requestId);
+    if (typeof include.request === "object" && include.request.select) {
+      const selected: any = {};
+      for (const key of Object.keys(include.request.select)) {
+        if (include.request.select[key] && request) selected[key] = request[key];
+      }
+      return { ...record, request: request ? selected : null };
+    }
+    return { ...record, request: request || null };
+  }
+  return record;
+});
+
+// Override findMany to support include: { request }
+const originalFindMany = mockPrisma.processingItem.findMany;
+mockPrisma.processingItem.findMany = mock(async (args: any = {}) => {
+  const results = await originalFindMany(args);
+  if (args.include?.request) {
+    return results.map((record: any) => {
+      const request = mediaRequestStore.get(record.requestId);
+      return { ...record, request: request || null };
+    });
+  }
+  return results;
+});
+
+mockPrisma.processingItem.update = mock(async ({ where, data }: any) => {
+  const record = processingItemStore.get(where.id);
+  if (!record) throw new Error(`Record ${where.id} not found`);
+  const updateData = { ...data };
+  if (data.attempts?.increment) {
+    updateData.attempts = (record.attempts || 0) + data.attempts.increment;
+  }
+  if (data.download) {
+    if (data.download.connect) updateData.downloadId = data.download.connect.id;
+    else if (data.download.disconnect) updateData.downloadId = null;
+    delete updateData.download;
+  }
+  const updated = { ...record, ...updateData, updatedAt: new Date() };
+  processingItemStore.set(where.id, updated);
+  return updated;
+});
+mockPrisma.processingItem.delete = mock(async ({ where }: any) => {
+  const record = processingItemStore.get(where.id);
+  processingItemStore.delete(where.id);
+  return record;
+});
+mockPrisma.processingItem.findFirst = mock(async ({ where }: any = {}) => {
+  const values = Array.from(processingItemStore.values());
+  if (!where) return values[0] || null;
+  return (
+    values.find((v: any) =>
+      Object.keys(where).every((k) => {
+        if (where[k]?.in) return where[k].in.includes(v[k]);
+        return v[k] === where[k];
+      })
+    ) || null
+  );
+});
+
+// Add deleteMany to processingItem mock
+mockPrisma.processingItem.deleteMany = mock(async ({ where }: any = {}) => {
+  let count = 0;
+  for (const [id, record] of processingItemStore.entries()) {
+    const matches =
+      !where ||
+      Object.keys(where).every((k) => {
+        if (k === "requestId") return record.requestId === where.requestId;
+        return record[k] === where[k];
+      });
+    if (matches) {
+      processingItemStore.delete(id);
+      count++;
+    }
+  }
+  return { count };
+});
+
+// Add deleteMany to download store
+const downloadStore = mockPrisma._stores.download;
+if (!mockPrisma.download) {
+  mockPrisma.download = {};
+}
+mockPrisma.download.deleteMany = mock(async ({ where }: any = {}) => {
+  let count = 0;
+  for (const [id, record] of downloadStore.entries()) {
+    const matches = !where || Object.keys(where).every((k) => record[k] === where[k]);
+    if (matches) {
+      downloadStore.delete(id);
+      count++;
+    }
+  }
+  return { count };
+});
+
+// Add deleteMany to activityLog store
+const _activityLogStore = mockPrisma._stores.activityLog;
+if (!mockPrisma.activityLog) {
+  mockPrisma.activityLog = {};
+}
+mockPrisma.activityLog.deleteMany = mock(async () => ({ count: 0 }));
+
+// Add delete to mediaRequest mock
+mockPrisma.mediaRequest.delete = mock(async ({ where }: any) => {
+  const record = mediaRequestStore.get(where.id);
+  mediaRequestStore.delete(where.id);
+  return record;
+});
+
+// Override mediaRequest.findUnique to support include: { processingItems }
+mockPrisma.mediaRequest.findUnique = mock(async ({ where, include }: any) => {
+  const record = mediaRequestStore.get(where.id);
+  if (!record) return null;
+  if (include?.processingItems) {
+    let items = Array.from(processingItemStore.values()).filter(
+      (item: any) => item.requestId === record.id
+    );
+    if (typeof include.processingItems === "object" && include.processingItems.where) {
+      const itemWhere = include.processingItems.where;
+      items = items.filter((item: any) =>
+        Object.keys(itemWhere).every((k) => item[k] === itemWhere[k])
+      );
+    }
+    return { ...record, processingItems: items };
+  }
+  return record;
+});
+
+// Mock episode library items
+if (!mockPrisma.episodeLibraryItem) {
+  mockPrisma.episodeLibraryItem = {
+    findMany: mock(async () => []),
+  };
+}
+
+// Mock $transaction
+mockPrisma.$transaction = mock(async (arg: any) => {
+  if (typeof arg === "function") {
+    return arg(mockPrisma);
+  }
+  return Promise.all(arg);
+});
+
+mock.module("../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+// Mock request status computer
+mock.module("../../services/requestStatusComputer.js", () => ({
+  requestStatusComputer: {
+    computeStatus: mock(async () => ({
+      status: "PENDING",
+      progress: 0,
+      currentStep: null,
+      currentStepStartedAt: null,
+      error: null,
+    })),
+    batchComputeStatus: mock(async (ids: string[]) => {
+      const map = new Map();
+      for (const id of ids) {
+        map.set(id, {
+          status: "PENDING",
+          progress: 0,
+          currentStep: null,
+          currentStepStartedAt: null,
+          error: null,
+        });
+      }
+      return map;
+    }),
+    getReleaseMetadata: mock(async () => null),
+  },
+}));
+
+// Mock trakt service
+const mockTraktService = {
+  getSeasons: mock(async () => [
+    { number: 1, title: "Season 1", episode_count: 3, overview: null, first_aired: null },
+  ]),
+  getSeason: mock(async () => ({
+    episodes: [
+      { number: 1, title: "Pilot", overview: null, first_aired: "2008-01-20T00:00:00Z" },
+      { number: 2, title: "Cat's in the Bag...", overview: null, first_aired: null },
+      { number: 3, title: "...And the Bag's in the River", overview: null, first_aired: null },
+    ],
+  })),
+};
+
+mock.module("../../services/trakt.js", () => ({
+  getTraktService: () => mockTraktService,
+}));
+
+// Mock download service
+mock.module("../../services/download.js", () => ({
+  getDownloadService: () => ({
+    getAllTorrents: mock(async () => []),
+  }),
+}));
+
+// Mock encoder dispatch service
+const mockEncoderDispatch = {
+  cancelJob: mock(async () => {}),
+};
+mock.module("../../services/encoderDispatch.js", () => ({
+  getEncoderDispatchService: () => mockEncoderDispatch,
+}));
+
+// Override methods on real singletons (avoids mock.module which leaks to other test files)
+const { pipelineOrchestrator } = await import("../../services/pipeline/PipelineOrchestrator.js");
+const { getPipelineExecutor } = await import("../../services/pipeline/PipelineExecutor.js");
+
+const mockExecutor = {
+  startExecution: mock(async () => {}),
+  cancelExecution: mock(async () => {}),
+};
+
+const executor = getPipelineExecutor();
+executor.startExecution = mockExecutor.startExecution;
+executor.cancelExecution = mockExecutor.cancelExecution;
+
+const mockOrchestrator = {
+  createRequest: mock(async (params: any) => {
+    const requestId = crypto.randomUUID();
+    const items =
+      params.type === "movie"
+        ? [{ id: crypto.randomUUID(), type: "MOVIE", tmdbId: params.tmdbId, status: "PENDING" }]
+        : (params.episodes || []).map((ep: any) => ({
+            id: crypto.randomUUID(),
+            type: "EPISODE",
+            tmdbId: params.tmdbId,
+            season: ep.season,
+            episode: ep.episode,
+            status: "PENDING",
+          }));
+
+    mockPrisma._stores.mediaRequest.set(requestId, {
+      id: requestId,
+      type: params.type === "movie" ? "MOVIE" : "TV",
+      tmdbId: params.tmdbId,
+      title: params.title,
+      year: params.year,
+      status: "PENDING",
+      progress: 0,
+      targets: [],
+      requestedSeasons: [],
+      requestedEpisodes: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return { requestId, items };
+  }),
+  retry: mock(async (itemId: string) => {
+    const item = mockPrisma._stores.processingItem.get(itemId);
+    if (!item) throw new Error("Item not found");
+    if (item.status !== "FAILED") throw new Error("Cannot retry non-FAILED item");
+    item.status = "PENDING";
+    item.attempts = 0;
+    return item;
+  }),
+  cancel: mock(async (itemId: string) => {
+    const item = mockPrisma._stores.processingItem.get(itemId);
+    if (!item) throw new Error("Item not found");
+    if (item.status === "COMPLETED" || item.status === "FAILED") {
+      throw new Error("Cannot cancel terminal item");
+    }
+    item.status = "CANCELLED";
+    return item;
+  }),
+  getRequestItems: mock(async (requestId: string) => {
+    return Array.from(mockPrisma._stores.processingItem.values()).filter(
+      (item: any) => item.requestId === requestId
+    );
+  }),
+  getRequestStats: mock(async () => ({
+    total: 1,
+    completed: 0,
+    failed: 0,
+    pending: 1,
+    inProgress: 0,
+  })),
+};
+
+// Replace methods on the real singleton (the router captures the same object reference)
+pipelineOrchestrator.createRequest = mockOrchestrator.createRequest as any;
+pipelineOrchestrator.retry = mockOrchestrator.retry as any;
+pipelineOrchestrator.cancel = mockOrchestrator.cancel as any;
+(pipelineOrchestrator as any).getRequestItems = mockOrchestrator.getRequestItems;
+(pipelineOrchestrator as any).getRequestStats = mockOrchestrator.getRequestStats;
+
+// Import router after all mocks and singleton overrides
+const { requestsRouter } = await import("../../routers/requests.js");
+const { router: createRouter } = await import("../../trpc.js");
+
+// Create a caller for testing
+const testRouter = createRouter({ requests: requestsRouter });
+const caller = testRouter.createCaller({
+  config: {} as any,
+  sessionToken: null,
+  user: null,
+});
+
+function seedDefaultTemplate(mediaType: string = "MOVIE") {
+  const id = `default-${mediaType.toLowerCase()}-template`;
+  mockPrisma._stores.pipelineTemplate.set(id, {
+    id,
+    name: `Default ${mediaType} Pipeline`,
+    mediaType,
+    isDefault: true,
+    steps: [{ type: "SEARCH", name: "Search", config: {} }],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return id;
+}
+
+function seedProcessingItem(overrides: Record<string, any> = {}) {
+  const id = overrides.id || crypto.randomUUID();
+  mockPrisma._stores.processingItem.set(id, {
+    id,
+    requestId: "req-1",
+    type: "EPISODE",
+    tmdbId: 1396,
+    title: "Pilot",
+    year: 2008,
+    season: 1,
+    episode: 1,
+    status: "PENDING",
+    stepContext: null,
+    attempts: 0,
+    maxAttempts: 5,
+    currentStep: null,
+    lastError: null,
+    nextRetryAt: null,
+    skipUntil: null,
+    progress: 0,
+    downloadId: null,
+    encodingJobId: null,
+    sourceFilePath: null,
+    cooldownEndsAt: null,
+    discoveredAt: null,
+    completedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+  return id;
+}
+
+function seedRequest(overrides: Record<string, any> = {}) {
+  const id = overrides.id || crypto.randomUUID();
+  mockPrisma._stores.mediaRequest.set(id, {
+    id,
+    type: "MOVIE",
+    tmdbId: 27205,
+    title: "Inception",
+    year: 2010,
+    posterPath: null,
+    status: "PENDING",
+    progress: 0,
+    targets: [{ serverId: "s1" }],
+    requestedSeasons: [],
+    requestedEpisodes: null,
+    error: null,
+    subscribe: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...overrides,
+  });
+  return id;
+}
+
+describe("Requests Router", () => {
+  beforeEach(() => {
+    mockPrisma._clear();
+    circuitBreakerStore.clear();
+    settingsStore.clear();
+    mockExecutor.startExecution.mockClear();
+    mockExecutor.cancelExecution.mockClear();
+    mockOrchestrator.createRequest.mockClear();
+    mockOrchestrator.retry.mockClear();
+    mockOrchestrator.cancel.mockClear();
+    mockEncoderDispatch.cancelJob.mockClear();
+  });
+
+  afterEach(() => {
+    mockPrisma._clear();
+  });
+
+  describe("createMovie", () => {
+    test("creates request with correct metadata", async () => {
+      seedDefaultTemplate("MOVIE");
+
+      const result = await caller.requests.createMovie({
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        targets: [{ serverId: "server-1" }],
+      });
+
+      expect(result.id).toBeDefined();
+      expect(mockOrchestrator.createRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "movie",
+          tmdbId: 27205,
+          title: "Inception",
+          year: 2010,
+        })
+      );
+    });
+
+    test("stores pipeline template for workers", async () => {
+      seedDefaultTemplate("MOVIE");
+
+      const result = await caller.requests.createMovie({
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        targets: [{ serverId: "server-1" }],
+      });
+
+      // A pipeline execution should be created
+      const executions = Array.from(mockPrisma._stores.pipelineExecution.values());
+      const exec = executions.find((e: any) => e.requestId === result.id);
+      expect(exec).toBeDefined();
+      expect((exec as any).status).toBe("RUNNING");
+    });
+
+    test("throws when no default template exists", async () => {
+      // Don't seed a template
+      await expect(
+        caller.requests.createMovie({
+          tmdbId: 27205,
+          title: "Inception",
+          year: 2010,
+          targets: [{ serverId: "server-1" }],
+        })
+      ).rejects.toThrow("No default pipeline template");
+    });
+  });
+
+  describe("cancel", () => {
+    test("cancels all processing items", async () => {
+      const reqId = seedRequest();
+      seedProcessingItem({ requestId: reqId, status: "DOWNLOADING" });
+      seedProcessingItem({ requestId: reqId, status: "PENDING" });
+
+      const result = await caller.requests.cancel({ id: reqId });
+      expect(result.success).toBe(true);
+    });
+
+    test("cancels encoding jobs", async () => {
+      const reqId = seedRequest();
+      const itemId = seedProcessingItem({
+        requestId: reqId,
+        status: "ENCODING",
+        encodingJobId: "job-1",
+      });
+
+      // Seed the mock stores with the encoding job
+      mockPrisma._stores.processingItem.get(itemId).encodingJobId = "job-1";
+
+      await caller.requests.cancel({ id: reqId });
+      // Encoding cancellation is called if items have encodingJobId
+    });
+  });
+
+  describe("delete", () => {
+    test("removes request and related data", async () => {
+      const reqId = seedRequest();
+      seedProcessingItem({ requestId: reqId });
+
+      const result = await caller.requests.delete({ id: reqId });
+      expect(result.success).toBe(true);
+
+      // Request should be deleted
+      expect(mockPrisma._stores.mediaRequest.get(reqId)).toBeUndefined();
+    });
+
+    test("returns error for non-existent request", async () => {
+      const result = await caller.requests.delete({ id: "nonexistent" });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Request not found");
+    });
+  });
+
+  describe("retry", () => {
+    test("resets all items to PENDING", async () => {
+      const reqId = seedRequest({ id: "retry-req" });
+      seedProcessingItem({
+        requestId: reqId,
+        status: "FAILED",
+        stepContext: { selectedRelease: { title: "test" } },
+      });
+
+      // Need a pipeline execution for retry
+      mockPrisma._stores.pipelineExecution.set("exec-1", {
+        id: "exec-1",
+        requestId: reqId,
+        templateId: seedDefaultTemplate("MOVIE"),
+        parentExecutionId: null,
+        status: "FAILED",
+        startedAt: new Date(),
+        currentStep: 0,
+        steps: [],
+        context: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await caller.requests.retry({ id: reqId });
+      expect(result.success).toBe(true);
+    });
+
+    test("throws for non-existent request", async () => {
+      await expect(caller.requests.retry({ id: "nonexistent" })).rejects.toThrow("not found");
+    });
+
+    test("throws when no pipeline execution found", async () => {
+      const reqId = seedRequest();
+      await expect(caller.requests.retry({ id: reqId })).rejects.toThrow(
+        "No pipeline execution found"
+      );
+    });
+
+    test("falls back to default template for branch pipelines", async () => {
+      const reqId = seedRequest({ id: "branch-retry-req" });
+      seedProcessingItem({ requestId: reqId, status: "FAILED" });
+
+      const defaultTemplateId = seedDefaultTemplate("MOVIE");
+
+      // Seed a branch pipeline execution
+      mockPrisma._stores.pipelineExecution.set("exec-branch", {
+        id: "exec-branch",
+        requestId: reqId,
+        templateId: "episode-branch-pipeline",
+        parentExecutionId: null,
+        status: "FAILED",
+        startedAt: new Date(),
+        currentStep: 0,
+        steps: [],
+        context: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await caller.requests.retry({ id: reqId });
+      expect(result.success).toBe(true);
+
+      // New execution should use the default template, not the branch one
+      const executions = Array.from(mockPrisma._stores.pipelineExecution.values()).filter(
+        (e: any) => e.requestId === reqId
+      );
+      const latestExec = executions[executions.length - 1];
+      expect((latestExec as any).templateId).toBe(defaultTemplateId);
+    });
+  });
+
+  describe("cancelEpisode", () => {
+    test("cancels episode via direct DB update (bypasses orchestrator)", async () => {
+      const itemId = seedProcessingItem({ status: "DOWNLOADING" });
+
+      const result = await caller.requests.cancelEpisode({ itemId });
+      expect(result.success).toBe(true);
+
+      const item = mockPrisma._stores.processingItem.get(itemId);
+      expect(item.status).toBe("CANCELLED");
+    });
+
+    test("BUG: can cancel COMPLETED episodes (bypasses orchestrator validation)", async () => {
+      const itemId = seedProcessingItem({ status: "COMPLETED" });
+
+      // This SHOULD fail but doesn't because it bypasses orchestrator validation
+      const result = await caller.requests.cancelEpisode({ itemId });
+      expect(result.success).toBe(true);
+
+      const item = mockPrisma._stores.processingItem.get(itemId);
+      expect(item.status).toBe("CANCELLED");
+    });
+  });
+
+  describe("retryEpisode", () => {
+    test("resets FAILED episode to PENDING", async () => {
+      const itemId = seedProcessingItem({
+        type: "EPISODE",
+        status: "FAILED",
+        lastError: "download failed",
+        attempts: 3,
+      });
+
+      const result = await caller.requests.retryEpisode({ itemId });
+      expect(result.success).toBe(true);
+
+      const item = mockPrisma._stores.processingItem.get(itemId);
+      expect(item.status).toBe("PENDING");
+      expect(item.attempts).toBe(0);
+      expect(item.lastError).toBeNull();
+    });
+
+    test("rejects non-EPISODE type", async () => {
+      const itemId = seedProcessingItem({ type: "MOVIE", status: "FAILED" });
+
+      await expect(caller.requests.retryEpisode({ itemId })).rejects.toThrow(
+        "Only episodes can be retried"
+      );
+    });
+
+    test("throws for non-existent item", async () => {
+      await expect(caller.requests.retryEpisode({ itemId: "nonexistent" })).rejects.toThrow(
+        "Episode not found"
+      );
+    });
+  });
+
+  describe("reEncodeEpisode", () => {
+    test("resets to DOWNLOADED preserving download context", async () => {
+      const itemId = seedProcessingItem({
+        type: "EPISODE",
+        status: "FAILED",
+        stepContext: {
+          download: { sourceFilePath: "/path/to/ep.mkv" },
+          encode: { encodedFiles: [{ path: "/encoded.mkv" }] },
+        },
+      });
+
+      const result = await caller.requests.reEncodeEpisode({ itemId });
+      expect(result.success).toBe(true);
+
+      const item = mockPrisma._stores.processingItem.get(itemId);
+      expect(item.status).toBe("DOWNLOADED");
+      expect(item.encodingJobId).toBeNull();
+    });
+
+    test("rejects when no source file path", async () => {
+      const itemId = seedProcessingItem({
+        type: "EPISODE",
+        status: "FAILED",
+        stepContext: {},
+        sourceFilePath: null,
+      });
+
+      await expect(caller.requests.reEncodeEpisode({ itemId })).rejects.toThrow(
+        "missing download file path"
+      );
+    });
+
+    test("uses top-level sourceFilePath as fallback", async () => {
+      const itemId = seedProcessingItem({
+        type: "EPISODE",
+        status: "ENCODED",
+        stepContext: {},
+        sourceFilePath: "/fallback/path.mkv",
+      });
+
+      const result = await caller.requests.reEncodeEpisode({ itemId });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("reDeliverEpisode", () => {
+    test("resets to ENCODED status", async () => {
+      const reqId = seedRequest({ type: "TV" });
+      const itemId = seedProcessingItem({
+        type: "EPISODE",
+        requestId: reqId,
+        status: "FAILED",
+        season: 1,
+        episode: 1,
+      });
+
+      const result = await caller.requests.reDeliverEpisode({ itemId });
+      expect(result.success).toBe(true);
+
+      const item = mockPrisma._stores.processingItem.get(itemId);
+      expect(item.status).toBe("ENCODED");
+      expect(item.deliveredAt).toBeNull();
+    });
+
+    test("rejects non-EPISODE type", async () => {
+      const reqId = seedRequest();
+      const itemId = seedProcessingItem({
+        type: "MOVIE",
+        requestId: reqId,
+        status: "FAILED",
+        season: null,
+        episode: null,
+      });
+
+      await expect(caller.requests.reDeliverEpisode({ itemId })).rejects.toThrow(
+        "Only episodes can be re-delivered"
+      );
+    });
+  });
+
+  describe("acceptLowerQuality", () => {
+    test("updates items with selected release", async () => {
+      const reqId = seedRequest({ id: "alq-req" });
+      const _itemId = seedProcessingItem({
+        requestId: reqId,
+        status: "FOUND",
+        stepContext: {
+          qualityMet: false,
+          alternativeReleases: [
+            { title: "Movie.720p.WEB-DL", resolution: "720p" },
+            { title: "Movie.480p.DVDRip", resolution: "480p" },
+          ],
+        },
+      });
+
+      const result = await caller.requests.acceptLowerQuality({
+        id: reqId,
+        releaseIndex: 0,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    test("throws for out-of-bounds release index", async () => {
+      const reqId = seedRequest({ id: "alq-bad-idx" });
+      seedProcessingItem({
+        requestId: reqId,
+        status: "FOUND",
+        stepContext: {
+          qualityMet: false,
+          alternativeReleases: [{ title: "Only release" }],
+        },
+      });
+
+      await expect(
+        caller.requests.acceptLowerQuality({ id: reqId, releaseIndex: 5 })
+      ).rejects.toThrow("Invalid release index");
+    });
+
+    test("throws when no alternatives available", async () => {
+      const reqId = seedRequest({ id: "alq-no-alts" });
+      seedProcessingItem({
+        requestId: reqId,
+        status: "FOUND",
+        stepContext: { qualityMet: true },
+      });
+
+      await expect(
+        caller.requests.acceptLowerQuality({ id: reqId, releaseIndex: 0 })
+      ).rejects.toThrow("No items waiting for quality acceptance");
+    });
+
+    test("throws when items not in FOUND status", async () => {
+      const reqId = seedRequest({ id: "alq-wrong-status" });
+      seedProcessingItem({
+        requestId: reqId,
+        status: "DOWNLOADING",
+        stepContext: {
+          qualityMet: false,
+          alternativeReleases: [{ title: "alt" }],
+        },
+      });
+
+      await expect(
+        caller.requests.acceptLowerQuality({ id: reqId, releaseIndex: 0 })
+      ).rejects.toThrow("No items waiting for quality acceptance");
+    });
+  });
+
+  describe("overrideDiscoveredRelease", () => {
+    test("updates selected release and resets cooldown to 30s", async () => {
+      const itemId = seedProcessingItem({
+        status: "DISCOVERED",
+        stepContext: { selectedRelease: { title: "old" } },
+        allSearchResults: [{ title: "result1" }, { title: "result2" }],
+        cooldownEndsAt: new Date(Date.now() + 600000),
+      });
+
+      const result = await caller.requests.overrideDiscoveredRelease({
+        itemId,
+        releaseIndex: 1,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.newCooldownEndsAt).toBeDefined();
+
+      // Check cooldown is ~30s from now
+      const diffMs = result.newCooldownEndsAt.getTime() - Date.now();
+      expect(diffMs).toBeGreaterThan(25000);
+      expect(diffMs).toBeLessThan(35000);
+    });
+
+    test("rejects non-DISCOVERED item", async () => {
+      const itemId = seedProcessingItem({
+        status: "DOWNLOADING",
+        allSearchResults: [{ title: "result1" }],
+      });
+
+      await expect(
+        caller.requests.overrideDiscoveredRelease({ itemId, releaseIndex: 0 })
+      ).rejects.toThrow("Cannot override release");
+    });
+
+    test("rejects invalid release index", async () => {
+      const itemId = seedProcessingItem({
+        status: "DISCOVERED",
+        allSearchResults: [{ title: "only one" }],
+      });
+
+      await expect(
+        caller.requests.overrideDiscoveredRelease({ itemId, releaseIndex: 5 })
+      ).rejects.toThrow("Invalid release index");
+    });
+  });
+
+  describe("approveDiscoveredItem", () => {
+    test("sets cooldown to 5 seconds from now", async () => {
+      const itemId = seedProcessingItem({
+        status: "DISCOVERED",
+        cooldownEndsAt: new Date(Date.now() + 600000),
+      });
+
+      const result = await caller.requests.approveDiscoveredItem({ itemId });
+      expect(result.success).toBe(true);
+
+      const diffMs = result.newCooldownEndsAt.getTime() - Date.now();
+      expect(diffMs).toBeGreaterThan(2000);
+      expect(diffMs).toBeLessThan(8000);
+    });
+
+    test("rejects non-DISCOVERED item", async () => {
+      const itemId = seedProcessingItem({ status: "DOWNLOADING" });
+
+      await expect(caller.requests.approveDiscoveredItem({ itemId })).rejects.toThrow(
+        "Only DISCOVERED items can be approved"
+      );
+    });
+  });
+
+  describe("retryItem", () => {
+    test("delegates to orchestrator.retry", async () => {
+      const itemId = seedProcessingItem({ status: "FAILED" });
+
+      const result = await caller.requests.retryItem({ itemId });
+      expect(result.success).toBe(true);
+      expect(mockOrchestrator.retry).toHaveBeenCalledWith(itemId);
+    });
+  });
+
+  describe("cancelItem", () => {
+    test("delegates to orchestrator.cancel", async () => {
+      const itemId = seedProcessingItem({ status: "DOWNLOADING" });
+
+      const result = await caller.requests.cancelItem({ itemId });
+      expect(result.success).toBe(true);
+      expect(mockOrchestrator.cancel).toHaveBeenCalledWith(itemId);
+    });
+  });
+});

--- a/packages/server/src/__tests__/routers/requests.test.ts
+++ b/packages/server/src/__tests__/routers/requests.test.ts
@@ -206,32 +206,32 @@ mock.module("../../db/client.js", () => ({
   db: mockPrisma,
 }));
 
-// Mock request status computer
-mock.module("../../services/requestStatusComputer.js", () => ({
-  requestStatusComputer: {
-    computeStatus: mock(async () => ({
+// Replace methods on real requestStatusComputer singleton to avoid mock.module
+// pollution (mock.module is process-global and leaks to other test files)
+const { requestStatusComputer: realStatusComputer } = await import(
+  "../../services/requestStatusComputer.js"
+);
+realStatusComputer.computeStatus = mock(async () => ({
+  status: "PENDING",
+  progress: 0,
+  currentStep: null,
+  currentStepStartedAt: null,
+  error: null,
+})) as any;
+realStatusComputer.batchComputeStatus = mock(async (ids: string[]) => {
+  const map = new Map();
+  for (const id of ids) {
+    map.set(id, {
       status: "PENDING",
       progress: 0,
       currentStep: null,
       currentStepStartedAt: null,
       error: null,
-    })),
-    batchComputeStatus: mock(async (ids: string[]) => {
-      const map = new Map();
-      for (const id of ids) {
-        map.set(id, {
-          status: "PENDING",
-          progress: 0,
-          currentStep: null,
-          currentStepStartedAt: null,
-          error: null,
-        });
-      }
-      return map;
-    }),
-    getReleaseMetadata: mock(async () => null),
-  },
-}));
+    });
+  }
+  return map;
+}) as any;
+realStatusComputer.getReleaseMetadata = mock(async () => null) as any;
 
 // Mock trakt service
 const mockTraktService = {

--- a/packages/server/src/__tests__/services/requestStatusComputer.test.ts
+++ b/packages/server/src/__tests__/services/requestStatusComputer.test.ts
@@ -6,6 +6,7 @@ import { createMockPrisma } from "../setup.js";
 const mockPrisma = createMockPrisma();
 mock.module("../../db/client.js", () => ({
   prisma: mockPrisma,
+  db: mockPrisma,
 }));
 
 // Import after mocking

--- a/packages/server/src/services/pipeline/__tests__/CircuitBreakerService.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/CircuitBreakerService.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createMockPrisma } from "../../../__tests__/setup.js";
+
+const mockPrisma = createMockPrisma();
+
+const circuitBreakerStore = new Map<string, any>();
+
+mockPrisma.circuitBreaker = {
+  findUnique: mock(async ({ where }: { where: { service: string } }) => {
+    return circuitBreakerStore.get(where.service) || null;
+  }),
+  create: mock(async ({ data }: { data: any }) => {
+    const record = { ...data, createdAt: new Date(), updatedAt: new Date() };
+    circuitBreakerStore.set(data.service, record);
+    return record;
+  }),
+  update: mock(async ({ where, data }: { where: { service: string }; data: any }) => {
+    const record = circuitBreakerStore.get(where.service);
+    if (!record) throw new Error(`CircuitBreaker ${where.service} not found`);
+    const updated = { ...record, ...data, updatedAt: new Date() };
+    circuitBreakerStore.set(where.service, updated);
+    return updated;
+  }),
+  findMany: mock(async (_opts: { orderBy?: any } = {}) => {
+    return Array.from(circuitBreakerStore.values());
+  }),
+};
+
+mock.module("../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+const { CircuitBreakerService, CircuitState } = await import("../CircuitBreakerService.js");
+
+describe("CircuitBreakerService", () => {
+  let service: InstanceType<typeof CircuitBreakerService>;
+
+  beforeEach(() => {
+    service = new CircuitBreakerService({
+      failureThreshold: 3,
+      halfOpenAfterMs: 5 * 60 * 1000,
+      successThreshold: 2,
+    });
+    circuitBreakerStore.clear();
+  });
+
+  afterEach(() => {
+    circuitBreakerStore.clear();
+  });
+
+  describe("isAvailable", () => {
+    test("returns true for new service (creates CLOSED breaker)", async () => {
+      const available = await service.isAvailable("new-service");
+      expect(available).toBe(true);
+      expect(circuitBreakerStore.get("new-service")?.state).toBe(CircuitState.CLOSED);
+    });
+
+    test("returns true for CLOSED circuit", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.CLOSED,
+        failures: 0,
+        lastFailure: null,
+        opensAt: null,
+      });
+      expect(await service.isAvailable("test")).toBe(true);
+    });
+
+    test("returns false for OPEN circuit within cooldown", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: new Date(Date.now() + 300000),
+      });
+      expect(await service.isAvailable("test")).toBe(false);
+    });
+
+    test("transitions OPEN to HALF_OPEN when cooldown expired", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.OPEN,
+        failures: 3,
+        lastFailure: new Date(Date.now() - 600000),
+        opensAt: new Date(Date.now() - 1000),
+      });
+      const available = await service.isAvailable("test");
+      expect(available).toBe(true);
+      expect(circuitBreakerStore.get("test").state).toBe(CircuitState.HALF_OPEN);
+    });
+
+    test("returns true for HALF_OPEN circuit", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.HALF_OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: null,
+      });
+      expect(await service.isAvailable("test")).toBe(true);
+    });
+  });
+
+  describe("recordSuccess", () => {
+    test("resets failure count in CLOSED state", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.CLOSED,
+        failures: 2,
+        lastFailure: new Date(),
+        opensAt: null,
+      });
+      await service.recordSuccess("test");
+      const breaker = circuitBreakerStore.get("test");
+      expect(breaker.failures).toBe(0);
+      expect(breaker.lastFailure).toBeNull();
+    });
+
+    test("increments success count in HALF_OPEN state", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.HALF_OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: null,
+      });
+
+      await service.recordSuccess("test");
+      // After 1 success, still HALF_OPEN (threshold is 2)
+      expect(circuitBreakerStore.get("test").state).toBe(CircuitState.HALF_OPEN);
+    });
+
+    test("transitions HALF_OPEN to CLOSED after successThreshold", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.HALF_OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: null,
+      });
+
+      await service.recordSuccess("test");
+      await service.recordSuccess("test");
+
+      const breaker = circuitBreakerStore.get("test");
+      expect(breaker.state).toBe(CircuitState.CLOSED);
+      expect(breaker.failures).toBe(0);
+    });
+  });
+
+  describe("recordFailure", () => {
+    test("creates breaker and increments failure on new service", async () => {
+      await service.recordFailure("new-svc", "connection refused");
+      const breaker = circuitBreakerStore.get("new-svc");
+      expect(breaker).toBeDefined();
+      expect(breaker.failures).toBe(1);
+      expect(breaker.state).toBe(CircuitState.CLOSED);
+    });
+
+    test("increments failure count", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.CLOSED,
+        failures: 1,
+        lastFailure: null,
+        opensAt: null,
+      });
+      await service.recordFailure("test", "error");
+      expect(circuitBreakerStore.get("test").failures).toBe(2);
+    });
+
+    test("transitions to OPEN at failure threshold", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.CLOSED,
+        failures: 2,
+        lastFailure: null,
+        opensAt: null,
+      });
+      await service.recordFailure("test", "error 3");
+      const breaker = circuitBreakerStore.get("test");
+      expect(breaker.state).toBe(CircuitState.OPEN);
+      expect(breaker.opensAt).toBeDefined();
+    });
+
+    test("HALF_OPEN failure immediately reopens circuit", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.HALF_OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: null,
+      });
+      await service.recordFailure("test", "failed during recovery");
+      expect(circuitBreakerStore.get("test").state).toBe(CircuitState.OPEN);
+    });
+  });
+
+  describe("reset", () => {
+    test("resets circuit to CLOSED with zero failures", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.OPEN,
+        failures: 5,
+        lastFailure: new Date(),
+        opensAt: new Date(Date.now() + 300000),
+      });
+      await service.reset("test");
+      const breaker = circuitBreakerStore.get("test");
+      expect(breaker.state).toBe(CircuitState.CLOSED);
+      expect(breaker.failures).toBe(0);
+      expect(breaker.opensAt).toBeNull();
+    });
+  });
+
+  describe("getState", () => {
+    test("returns current state", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: new Date(),
+      });
+      expect(await service.getState("test")).toBe(CircuitState.OPEN);
+    });
+
+    test("returns CLOSED for new service", async () => {
+      expect(await service.getState("new-service")).toBe(CircuitState.CLOSED);
+    });
+  });
+
+  describe("getBreakerInfo", () => {
+    test("returns info for existing breaker", async () => {
+      const now = new Date();
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.OPEN,
+        failures: 3,
+        lastFailure: now,
+        opensAt: new Date(now.getTime() + 300000),
+      });
+      const info = await service.getBreakerInfo("test");
+      expect(info).toBeDefined();
+      expect(info?.service).toBe("test");
+      expect(info?.state).toBe(CircuitState.OPEN);
+      expect(info?.failures).toBe(3);
+    });
+
+    test("returns null for non-existent breaker", async () => {
+      const info = await service.getBreakerInfo("nonexistent");
+      expect(info).toBeNull();
+    });
+  });
+
+  describe("getAllBreakers", () => {
+    test("returns all breakers", async () => {
+      circuitBreakerStore.set("svc-1", {
+        service: "svc-1",
+        state: CircuitState.CLOSED,
+        failures: 0,
+        lastFailure: null,
+        opensAt: null,
+        updatedAt: new Date(),
+      });
+      circuitBreakerStore.set("svc-2", {
+        service: "svc-2",
+        state: CircuitState.OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const breakers = await service.getAllBreakers();
+      expect(breakers).toHaveLength(2);
+    });
+  });
+
+  describe("state transition lifecycle", () => {
+    test("full lifecycle: CLOSED -> OPEN -> HALF_OPEN -> CLOSED", async () => {
+      // Start CLOSED
+      circuitBreakerStore.set("lifecycle", {
+        service: "lifecycle",
+        state: CircuitState.CLOSED,
+        failures: 0,
+        lastFailure: null,
+        opensAt: null,
+      });
+
+      // Record failures to open
+      await service.recordFailure("lifecycle", "fail 1");
+      await service.recordFailure("lifecycle", "fail 2");
+      await service.recordFailure("lifecycle", "fail 3");
+      expect(circuitBreakerStore.get("lifecycle").state).toBe(CircuitState.OPEN);
+
+      // Simulate cooldown expiry by setting opensAt to past
+      circuitBreakerStore.get("lifecycle").opensAt = new Date(Date.now() - 1000);
+      const available = await service.isAvailable("lifecycle");
+      expect(available).toBe(true);
+      expect(circuitBreakerStore.get("lifecycle").state).toBe(CircuitState.HALF_OPEN);
+
+      // Record successes to close
+      await service.recordSuccess("lifecycle");
+      await service.recordSuccess("lifecycle");
+      expect(circuitBreakerStore.get("lifecycle").state).toBe(CircuitState.CLOSED);
+      expect(circuitBreakerStore.get("lifecycle").failures).toBe(0);
+    });
+
+    test("HALF_OPEN -> OPEN on failure", async () => {
+      circuitBreakerStore.set("test", {
+        service: "test",
+        state: CircuitState.HALF_OPEN,
+        failures: 3,
+        lastFailure: new Date(),
+        opensAt: null,
+      });
+
+      // One success then a failure
+      await service.recordSuccess("test");
+      await service.recordFailure("test", "still broken");
+      expect(circuitBreakerStore.get("test").state).toBe(CircuitState.OPEN);
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/PipelineExecutorExpanded.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/PipelineExecutorExpanded.test.ts
@@ -1,0 +1,627 @@
+/**
+ * PipelineExecutor Expanded Tests
+ *
+ * Tests for condition evaluation, pause/resume, retry hints,
+ * context loading, and edge cases not covered in the base executor tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { StepType } from "@prisma/client";
+import { createMockPrisma } from "../../../__tests__/setup.js";
+import type { ConditionRule, PipelineContext, StepOutput } from "../PipelineContext.js";
+
+const mockPrisma = createMockPrisma();
+mock.module("../../../db/client.js", () => ({
+  prisma: mockPrisma,
+}));
+
+import { PipelineExecutor } from "../PipelineExecutor.js";
+import { StepRegistry } from "../StepRegistry.js";
+import { BaseStep } from "../steps/BaseStep.js";
+
+class ConfigurableStep extends BaseStep {
+  static executionLog: Array<{ name: string; timestamp: number }> = [];
+  static resetLog() {
+    ConfigurableStep.executionLog = [];
+  }
+
+  constructor(public readonly type: StepType) {
+    super();
+  }
+
+  async execute(_context: PipelineContext, config: unknown): Promise<StepOutput> {
+    const cfg = config as {
+      name: string;
+      delay?: number;
+      shouldFail?: boolean;
+      shouldPause?: boolean;
+      shouldRetry?: boolean;
+      shouldSkip?: boolean;
+      nextStep?: string | null;
+      data?: Record<string, unknown>;
+    };
+
+    ConfigurableStep.executionLog.push({ name: cfg.name, timestamp: Date.now() });
+
+    if (cfg.delay) {
+      await new Promise((resolve) => setTimeout(resolve, cfg.delay));
+    }
+
+    if (cfg.shouldPause) {
+      return { success: true, shouldPause: true };
+    }
+
+    if (cfg.shouldRetry) {
+      return { success: false, shouldRetry: true, error: "Retry needed" };
+    }
+
+    if (cfg.shouldSkip) {
+      return { success: true, shouldSkip: true };
+    }
+
+    if (cfg.shouldFail) {
+      return { success: false, error: `Step ${cfg.name} failed` };
+    }
+
+    return {
+      success: true,
+      data: cfg.data || { [`${cfg.name}_completed`]: true },
+      nextStep: cfg.nextStep,
+    };
+  }
+
+  validateConfig(config: unknown): void {
+    const cfg = config as { name?: string };
+    if (!cfg || typeof cfg.name !== "string") {
+      throw new Error("Step requires config with name");
+    }
+  }
+}
+
+describe("PipelineExecutor - Expanded", () => {
+  let executor: PipelineExecutor;
+  let mockRequestId: string;
+
+  beforeEach(async () => {
+    executor = new PipelineExecutor();
+    ConfigurableStep.resetLog();
+    mockPrisma._clear();
+
+    StepRegistry.reset();
+
+    const types = ["SEARCH", "DOWNLOAD", "ENCODE", "DELIVER", "NOTIFICATION", "APPROVAL"];
+    for (const t of types) {
+      const stepType = t as StepType;
+      class DynStep extends ConfigurableStep {
+        constructor() {
+          super(stepType);
+        }
+      }
+      StepRegistry.register(stepType, DynStep);
+    }
+
+    const request = await mockPrisma.mediaRequest.create({
+      data: {
+        type: "MOVIE",
+        tmdbId: 12345,
+        title: "Test Movie",
+        year: 2024,
+        status: "PENDING",
+        targets: [],
+      },
+    });
+    mockRequestId = request.id;
+  });
+
+  afterEach(() => {
+    mockPrisma._clear();
+  });
+
+  async function createTemplate(steps: unknown[]) {
+    const template = await mockPrisma.pipelineTemplate.create({
+      data: {
+        name: "Test Template",
+        mediaType: "MOVIE",
+        isPublic: true,
+        isDefault: false,
+        steps,
+      },
+    });
+    return template.id;
+  }
+
+  describe("Condition Evaluation", () => {
+    it("skips step when condition evaluates to false", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Conditional Step",
+          config: { name: "conditional" },
+          condition: { field: "mediaType", operator: "==", value: "TV" },
+          required: true,
+          continueOnError: false,
+        },
+        {
+          type: "NOTIFICATION",
+          name: "Always Runs",
+          config: { name: "always" },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const names = ConfigurableStep.executionLog.map((l) => l.name);
+      expect(names).toContain("always");
+      expect(names).not.toContain("conditional");
+    });
+
+    it("executes step when condition evaluates to true", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Movie Step",
+          config: { name: "movie_step" },
+          condition: { field: "mediaType", operator: "==", value: "MOVIE" },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      expect(ConfigurableStep.executionLog.map((l) => l.name)).toContain("movie_step");
+    });
+
+    it("handles != operator", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Not TV",
+          config: { name: "not_tv" },
+          condition: { field: "mediaType", operator: "!=", value: "TV" },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+      expect(ConfigurableStep.executionLog.map((l) => l.name)).toContain("not_tv");
+    });
+
+    it("handles 'in' operator", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "In Check",
+          config: { name: "in_check" },
+          condition: { field: "mediaType", operator: "in", value: ["MOVIE", "TV"] },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+      expect(ConfigurableStep.executionLog.map((l) => l.name)).toContain("in_check");
+    });
+  });
+
+  describe("shouldPause behavior", () => {
+    it("throws pause error when step returns shouldPause", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "APPROVAL",
+          name: "Pause Step",
+          config: { name: "pause_step", shouldPause: true },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await expect(executor.startExecution(mockRequestId, templateId)).rejects.toThrow("paused");
+
+      // Note: pauseExecution sets PAUSED, but the error propagates to
+      // startExecution's catch block which calls failExecution, overriding
+      // the status to FAILED. This is an existing behavior where failExecution
+      // only skips if status is already FAILED, not PAUSED.
+      const execution = await mockPrisma.pipelineExecution.findFirst({
+        where: { requestId: mockRequestId },
+      });
+      expect(execution?.status).toBe("FAILED");
+    });
+  });
+
+  describe("shouldRetry behavior", () => {
+    it("completes execution when step returns shouldRetry", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Retry Step",
+          config: { name: "retry_step", shouldRetry: true },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const execution = await mockPrisma.pipelineExecution.findFirst({
+        where: { requestId: mockRequestId },
+      });
+      expect(execution?.status).toBe("COMPLETED");
+    });
+  });
+
+  describe("shouldSkip behavior", () => {
+    it("skips step and continues to siblings", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Skip Step",
+          config: { name: "skip_step", shouldSkip: true },
+          required: true,
+          continueOnError: false,
+        },
+        {
+          type: "NOTIFICATION",
+          name: "After Skip",
+          config: { name: "after_skip" },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const names = ConfigurableStep.executionLog.map((l) => l.name);
+      expect(names).toContain("skip_step");
+      expect(names).toContain("after_skip");
+    });
+  });
+
+  describe("nextStep override", () => {
+    it("stops pipeline when nextStep is null", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Stop Step",
+          config: { name: "stop_step", nextStep: null, data: { stopped: true } },
+          required: true,
+          continueOnError: false,
+          children: [
+            {
+              type: "DOWNLOAD",
+              name: "Should Not Run",
+              config: { name: "should_not_run" },
+              required: true,
+              continueOnError: false,
+            },
+          ],
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const names = ConfigurableStep.executionLog.map((l) => l.name);
+      expect(names).toContain("stop_step");
+      expect(names).not.toContain("should_not_run");
+    });
+  });
+
+  describe("Deep nesting", () => {
+    it("executes 3+ levels of parent -> child -> grandchild", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Level 1",
+          config: { name: "level_1" },
+          required: true,
+          continueOnError: false,
+          children: [
+            {
+              type: "DOWNLOAD",
+              name: "Level 2",
+              config: { name: "level_2" },
+              required: true,
+              continueOnError: false,
+              children: [
+                {
+                  type: "ENCODE",
+                  name: "Level 3",
+                  config: { name: "level_3" },
+                  required: true,
+                  continueOnError: false,
+                  children: [
+                    {
+                      type: "DELIVER",
+                      name: "Level 4",
+                      config: { name: "level_4" },
+                      required: true,
+                      continueOnError: false,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const names = ConfigurableStep.executionLog.map((l) => l.name);
+      expect(names).toEqual(["level_1", "level_2", "level_3", "level_4"]);
+    });
+  });
+
+  describe("Mixed tree execution", () => {
+    it("handles parallel branches where one has sequential children", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Branch A",
+          config: { name: "branch_a", delay: 10 },
+          required: true,
+          continueOnError: false,
+          children: [
+            {
+              type: "DOWNLOAD",
+              name: "A Child",
+              config: { name: "a_child" },
+              required: true,
+              continueOnError: false,
+            },
+          ],
+        },
+        {
+          type: "NOTIFICATION",
+          name: "Branch B (leaf)",
+          config: { name: "branch_b" },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const names = ConfigurableStep.executionLog.map((l) => l.name);
+      expect(names).toContain("branch_a");
+      expect(names).toContain("a_child");
+      expect(names).toContain("branch_b");
+      expect(names).toHaveLength(3);
+    });
+  });
+
+  describe("Empty step tree", () => {
+    it("completes immediately with no steps", async () => {
+      const templateId = await createTemplate([]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const execution = await mockPrisma.pipelineExecution.findFirst({
+        where: { requestId: mockRequestId },
+      });
+      expect(execution?.status).toBe("COMPLETED");
+      expect(ConfigurableStep.executionLog).toHaveLength(0);
+    });
+  });
+
+  describe("Step registry miss", () => {
+    it("throws when step type not registered", async () => {
+      StepRegistry.reset();
+      // Don't register any steps
+
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Unregistered",
+          config: { name: "test" },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await expect(executor.startExecution(mockRequestId, templateId)).rejects.toThrow();
+    });
+  });
+
+  describe("Context preservation", () => {
+    it("preserves core context fields through step execution", async () => {
+      const templateId = await createTemplate([
+        {
+          type: "SEARCH",
+          name: "Context Step",
+          config: {
+            name: "context_step",
+            data: {
+              requestId: "should-not-overwrite",
+              title: "should-not-overwrite",
+              customField: "should-persist",
+            },
+          },
+          required: true,
+          continueOnError: false,
+        },
+      ]);
+
+      await executor.startExecution(mockRequestId, templateId);
+
+      const execution = await mockPrisma.pipelineExecution.findFirst({
+        where: { requestId: mockRequestId },
+      });
+
+      const context = execution?.context as Record<string, unknown>;
+      expect(context.requestId).toBe(mockRequestId);
+      expect(context.title).toBe("Test Movie");
+      expect(context.customField).toBe("should-persist");
+    });
+  });
+});
+
+describe("BaseStep - Condition Evaluation", () => {
+  class TestStep extends BaseStep {
+    readonly type = "SEARCH" as StepType;
+
+    validateConfig(): void {}
+    async execute(): Promise<StepOutput> {
+      return { success: true };
+    }
+  }
+
+  const step = new TestStep();
+
+  function makeContext(overrides: Partial<PipelineContext> = {}): PipelineContext {
+    return {
+      requestId: "test-req",
+      mediaType: "MOVIE" as any,
+      tmdbId: 27205,
+      title: "Inception",
+      year: 2010,
+      targets: [],
+      ...overrides,
+    };
+  }
+
+  it("returns true when no condition", () => {
+    expect(step.evaluateCondition(makeContext())).toBe(true);
+  });
+
+  it("handles == operator", () => {
+    const condition: ConditionRule = { field: "mediaType", operator: "==", value: "MOVIE" };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+
+    condition.value = "TV";
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(false);
+  });
+
+  it("handles != operator", () => {
+    const condition: ConditionRule = { field: "mediaType", operator: "!=", value: "TV" };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+
+  it("handles > and < operators", () => {
+    const context = makeContext({ year: 2010 });
+    expect(step.evaluateCondition(context, { field: "year", operator: ">", value: 2005 })).toBe(
+      true
+    );
+    expect(step.evaluateCondition(context, { field: "year", operator: ">", value: 2020 })).toBe(
+      false
+    );
+    expect(step.evaluateCondition(context, { field: "year", operator: "<", value: 2020 })).toBe(
+      true
+    );
+  });
+
+  it("handles >= and <= operators", () => {
+    const context = makeContext({ year: 2010 });
+    expect(step.evaluateCondition(context, { field: "year", operator: ">=", value: 2010 })).toBe(
+      true
+    );
+    expect(step.evaluateCondition(context, { field: "year", operator: "<=", value: 2010 })).toBe(
+      true
+    );
+  });
+
+  it("handles 'in' operator", () => {
+    const condition: ConditionRule = {
+      field: "mediaType",
+      operator: "in",
+      value: ["MOVIE", "TV"],
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+
+    condition.value = ["TV", "ANIME"];
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(false);
+  });
+
+  it("handles 'not_in' operator", () => {
+    const condition: ConditionRule = {
+      field: "mediaType",
+      operator: "not_in",
+      value: ["TV", "ANIME"],
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+
+  it("handles 'contains' operator", () => {
+    const condition: ConditionRule = {
+      field: "title",
+      operator: "contains",
+      value: "cepti",
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+
+  it("handles 'matches' operator", () => {
+    const condition: ConditionRule = {
+      field: "title",
+      operator: "matches",
+      value: "^In.*on$",
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+
+  it("handles nested AND conditions", () => {
+    const condition: ConditionRule = {
+      field: "",
+      operator: "==",
+      value: "",
+      logicalOp: "AND",
+      conditions: [
+        { field: "mediaType", operator: "==", value: "MOVIE" },
+        { field: "year", operator: ">", value: 2005 },
+      ],
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+
+  it("handles nested OR conditions", () => {
+    const condition: ConditionRule = {
+      field: "",
+      operator: "==",
+      value: "",
+      logicalOp: "OR",
+      conditions: [
+        { field: "mediaType", operator: "==", value: "TV" },
+        { field: "year", operator: "==", value: 2010 },
+      ],
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+
+  it("returns false for AND when one condition fails", () => {
+    const condition: ConditionRule = {
+      field: "",
+      operator: "==",
+      value: "",
+      logicalOp: "AND",
+      conditions: [
+        { field: "mediaType", operator: "==", value: "MOVIE" },
+        { field: "year", operator: ">", value: 2020 },
+      ],
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(false);
+  });
+
+  it("handles dot notation for nested context fields", () => {
+    const context = makeContext({
+      search: { selectedRelease: { resolution: "1080p" } as any },
+    } as any);
+    const condition: ConditionRule = {
+      field: "search.selectedRelease.resolution",
+      operator: "==",
+      value: "1080p",
+    };
+    expect(step.evaluateCondition(context, condition)).toBe(true);
+  });
+
+  it("returns undefined for non-existent nested path", () => {
+    const condition: ConditionRule = {
+      field: "nonexistent.deep.path",
+      operator: "==",
+      value: undefined,
+    };
+    expect(step.evaluateCondition(makeContext(), condition)).toBe(true);
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/PipelineOrchestrator.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/PipelineOrchestrator.test.ts
@@ -1,0 +1,604 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createMockPrisma } from "../../../__tests__/setup.js";
+
+const mockPrisma = createMockPrisma();
+
+// Add circuit breaker + settings stores
+const circuitBreakerStore = new Map<string, any>();
+const settingsStore = new Map<string, any>();
+
+mockPrisma.circuitBreaker = {
+  findUnique: mock(async ({ where }: { where: { service: string } }) => {
+    return circuitBreakerStore.get(where.service) || null;
+  }),
+  create: mock(async ({ data }: { data: any }) => {
+    const record = { ...data, createdAt: new Date(), updatedAt: new Date() };
+    circuitBreakerStore.set(data.service, record);
+    return record;
+  }),
+  update: mock(async ({ where, data }: { where: { service: string }; data: any }) => {
+    const record = circuitBreakerStore.get(where.service);
+    if (!record) throw new Error(`CircuitBreaker ${where.service} not found`);
+    const updated = { ...record, ...data, updatedAt: new Date() };
+    circuitBreakerStore.set(where.service, updated);
+    return updated;
+  }),
+  findMany: mock(async () => Array.from(circuitBreakerStore.values())),
+};
+
+mockPrisma.settings = {
+  findUnique: mock(async ({ where }: { where: { id: string } }) => {
+    return settingsStore.get(where.id) || null;
+  }),
+};
+
+// Add processingItem.delete to the mock (missing from base setup)
+const originalProcessingItemStore = mockPrisma._stores.processingItem;
+if (!mockPrisma.processingItem.delete) {
+  mockPrisma.processingItem.delete = mock(async ({ where }: { where: { id: string } }) => {
+    const record = originalProcessingItemStore.get(where.id);
+    if (!record) throw new Error(`ProcessingItem ${where.id} not found`);
+    originalProcessingItemStore.delete(where.id);
+    return record;
+  });
+}
+
+// Add processingItem.update to the mock
+if (!mockPrisma.processingItem.update) {
+  mockPrisma.processingItem.update = mock(
+    async ({ where, data }: { where: { id: string }; data: any }) => {
+      const record = originalProcessingItemStore.get(where.id);
+      if (!record) throw new Error(`ProcessingItem ${where.id} not found`);
+      const updated = { ...record, ...data, updatedAt: new Date() };
+      // Handle increment syntax
+      if (data.attempts?.increment) {
+        updated.attempts = (record.attempts || 0) + data.attempts.increment;
+      }
+      originalProcessingItemStore.set(where.id, updated);
+      return updated;
+    }
+  );
+}
+
+// Add mediaRequest.delete
+if (!mockPrisma.mediaRequest.delete) {
+  mockPrisma.mediaRequest.delete = mock(async ({ where }: { where: { id: string } }) => {
+    const record = mockPrisma._stores.mediaRequest.get(where.id);
+    mockPrisma._stores.mediaRequest.delete(where.id);
+    return record;
+  });
+}
+
+mock.module("../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+const { PipelineOrchestrator } = await import("../PipelineOrchestrator.js");
+const { StateTransitionError } = await import("../StateMachine.js");
+const { ValidationError } = await import("../ValidationFramework.js");
+
+describe("PipelineOrchestrator", () => {
+  let orchestrator: InstanceType<typeof PipelineOrchestrator>;
+
+  beforeEach(() => {
+    orchestrator = new PipelineOrchestrator();
+    mockPrisma._clear();
+    circuitBreakerStore.clear();
+    settingsStore.clear();
+  });
+
+  afterEach(() => {
+    mockPrisma._clear();
+    circuitBreakerStore.clear();
+    settingsStore.clear();
+  });
+
+  function seedTemplate(type: string = "movie") {
+    const id = type === "movie" ? "default-movie-pipeline" : "default-tv-pipeline";
+    mockPrisma._stores.pipelineTemplate.set(id, {
+      id,
+      name: `Default ${type} pipeline`,
+      mediaType: type.toUpperCase(),
+      steps: [{ type: "SEARCH", name: "Search", config: {} }],
+      isDefault: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  describe("createRequest", () => {
+    test("creates a movie request with 1 ProcessingItem", async () => {
+      seedTemplate("movie");
+
+      const result = await orchestrator.createRequest({
+        type: "movie",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        targetServers: ["server-1"],
+      });
+
+      expect(result.requestId).toBeDefined();
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].type).toBe("MOVIE");
+      expect(result.items[0].tmdbId).toBe(27205);
+      expect(result.items[0].status).toBe("PENDING");
+    });
+
+    test("creates a TV request with multiple ProcessingItems", async () => {
+      seedTemplate("tv");
+
+      const result = await orchestrator.createRequest({
+        type: "tv",
+        tmdbId: 1396,
+        title: "Breaking Bad",
+        year: 2008,
+        episodes: [
+          { season: 1, episode: 1, title: "Pilot" },
+          { season: 1, episode: 2, title: "Cat's in the Bag..." },
+          { season: 1, episode: 3, title: "...And the Bag's in the River" },
+        ],
+        targetServers: ["server-1"],
+      });
+
+      expect(result.items).toHaveLength(3);
+      expect(result.items[0].type).toBe("EPISODE");
+      expect(result.items[0].season).toBe(1);
+      expect(result.items[0].episode).toBe(1);
+      expect(result.items[2].episode).toBe(3);
+    });
+
+    test("throws when pipeline template not found", async () => {
+      await expect(
+        orchestrator.createRequest({
+          type: "movie",
+          tmdbId: 1,
+          title: "Test",
+          targetServers: ["s1"],
+        })
+      ).rejects.toThrow("Pipeline template");
+    });
+
+    test("throws when TV request has no episodes", async () => {
+      seedTemplate("tv");
+
+      await expect(
+        orchestrator.createRequest({
+          type: "tv",
+          tmdbId: 1,
+          title: "Test",
+          episodes: [],
+          targetServers: ["s1"],
+        })
+      ).rejects.toThrow("must include episodes");
+    });
+
+    test("creates MediaRequest in database", async () => {
+      seedTemplate("movie");
+
+      const result = await orchestrator.createRequest({
+        type: "movie",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        targetServers: ["server-1"],
+      });
+
+      const request = mockPrisma._stores.mediaRequest.get(result.requestId);
+      expect(request).toBeDefined();
+      expect(request.type).toBe("MOVIE");
+      expect(request.status).toBe("PENDING");
+    });
+
+    test("creates PipelineExecution for compatibility", async () => {
+      seedTemplate("movie");
+
+      const result = await orchestrator.createRequest({
+        type: "movie",
+        tmdbId: 1,
+        title: "Test",
+        targetServers: ["s1"],
+      });
+
+      const executions = Array.from(mockPrisma._stores.pipelineExecution.values());
+      const exec = executions.find((e: any) => e.requestId === result.requestId);
+      expect(exec).toBeDefined();
+      expect((exec as any).status).toBe("RUNNING");
+    });
+  });
+
+  describe("transitionStatus", () => {
+    async function createItemInDb(status: string, stepContext: any = null) {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        status,
+        stepContext,
+        attempts: 0,
+        maxAttempts: 5,
+        currentStep: null,
+        lastError: null,
+        nextRetryAt: null,
+        skipUntil: null,
+        progress: 0,
+        downloadId: null,
+        encodingJobId: null,
+        cooldownEndsAt: null,
+        discoveredAt: null,
+        completedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      return id;
+    }
+
+    test("valid transition updates status", async () => {
+      const itemId = await createItemInDb("PENDING");
+
+      const updated = await orchestrator.transitionStatus(itemId, "SEARCHING");
+      expect(updated.status).toBe("SEARCHING");
+    });
+
+    test("invalid transition throws StateTransitionError", async () => {
+      const itemId = await createItemInDb("COMPLETED");
+
+      await expect(orchestrator.transitionStatus(itemId, "PENDING")).rejects.toThrow(
+        StateTransitionError
+      );
+    });
+
+    test("validation failure throws ValidationError", async () => {
+      const itemId = await createItemInDb("SEARCHING", {});
+
+      // FOUND requires selectedRelease in context - transition will fail at exit validation
+      await expect(orchestrator.transitionStatus(itemId, "FOUND")).rejects.toThrow(ValidationError);
+    });
+
+    test("passes validation with correct context", async () => {
+      const itemId = await createItemInDb("PENDING");
+
+      const updated = await orchestrator.transitionStatus(itemId, "FOUND", {
+        stepContext: { selectedRelease: { title: "test" } },
+      });
+      expect(updated.status).toBe("FOUND");
+    });
+
+    test("throws when item not found", async () => {
+      await expect(orchestrator.transitionStatus("nonexistent", "SEARCHING")).rejects.toThrow(
+        "not found"
+      );
+    });
+  });
+
+  describe("handleError", () => {
+    async function createItemInDb(status: string, overrides: any = {}) {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        status,
+        stepContext: null,
+        attempts: 0,
+        maxAttempts: 5,
+        currentStep: null,
+        lastError: null,
+        nextRetryAt: null,
+        skipUntil: null,
+        progress: 0,
+        errorHistory: null,
+        downloadId: null,
+        encodingJobId: null,
+        cooldownEndsAt: null,
+        discoveredAt: null,
+        completedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+      });
+      return id;
+    }
+
+    test("transient error sets retry with nextRetryAt", async () => {
+      settingsStore.set("default", { searchRetryIntervalHours: 6 });
+      const itemId = await createItemInDb("DOWNLOADING");
+
+      const updated = await orchestrator.handleError(itemId, "503 service unavailable");
+      expect(updated.status).toBe("DOWNLOADING"); // Stays in processing status
+      expect(updated.nextRetryAt).toBeDefined();
+      expect(updated.attempts).toBe(1);
+    });
+
+    test("permanent error transitions to FAILED", async () => {
+      const itemId = await createItemInDb("DOWNLOADING");
+
+      const updated = await orchestrator.handleError(itemId, "404 not found");
+      expect(updated.status).toBe("FAILED");
+      expect(updated.completedAt).toBeDefined();
+    });
+
+    test("max attempts exceeded transitions to FAILED", async () => {
+      const itemId = await createItemInDb("DOWNLOADING", {
+        attempts: 5,
+        maxAttempts: 5,
+      });
+
+      const updated = await orchestrator.handleError(itemId, "network error");
+      expect(updated.status).toBe("FAILED");
+    });
+
+    test("network error with open circuit uses skipUntil", async () => {
+      circuitBreakerStore.set("qbit", {
+        service: "qbit",
+        state: "OPEN",
+        failures: 5,
+        lastFailure: new Date(),
+        opensAt: new Date(Date.now() + 300000),
+      });
+
+      const itemId = await createItemInDb("DOWNLOADING");
+      const updated = await orchestrator.handleError(itemId, "econnrefused", "qbit");
+      expect(updated.skipUntil).toBeDefined();
+      // Should NOT increment attempts for service outage
+      expect(updated.attempts).toBe(0);
+    });
+
+    test("keeps processing status for items already in processing state", async () => {
+      settingsStore.set("default", { searchRetryIntervalHours: 6 });
+      const itemId = await createItemInDb("ENCODING");
+
+      const updated = await orchestrator.handleError(itemId, "502 bad gateway");
+      expect(updated.status).toBe("ENCODING");
+    });
+
+    test("throws when item not found", async () => {
+      await expect(orchestrator.handleError("nonexistent", "error")).rejects.toThrow("not found");
+    });
+
+    test("builds error history", async () => {
+      settingsStore.set("default", { searchRetryIntervalHours: 6 });
+      const itemId = await createItemInDb("DOWNLOADING");
+
+      await orchestrator.handleError(itemId, "first error");
+
+      const item = mockPrisma._stores.processingItem.get(itemId);
+      expect(item.errorHistory).toBeDefined();
+      const history = item.errorHistory as any[];
+      expect(history.length).toBeGreaterThan(0);
+      expect(history[0].error).toBe("first error");
+    });
+  });
+
+  describe("cancel", () => {
+    async function createItemInDb(status: string) {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        status,
+        stepContext: null,
+        attempts: 0,
+        maxAttempts: 5,
+        currentStep: null,
+        lastError: null,
+        nextRetryAt: null,
+        skipUntil: null,
+        progress: 0,
+        downloadId: null,
+        encodingJobId: null,
+        cooldownEndsAt: null,
+        discoveredAt: null,
+        completedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      return id;
+    }
+
+    test("cancels PENDING item", async () => {
+      const itemId = await createItemInDb("PENDING");
+      const updated = await orchestrator.cancel(itemId);
+      expect(updated.status).toBe("CANCELLED");
+    });
+
+    test("cancels DOWNLOADING item", async () => {
+      const itemId = await createItemInDb("DOWNLOADING");
+      const updated = await orchestrator.cancel(itemId);
+      expect(updated.status).toBe("CANCELLED");
+    });
+
+    test("throws for COMPLETED item", async () => {
+      const itemId = await createItemInDb("COMPLETED");
+      await expect(orchestrator.cancel(itemId)).rejects.toThrow("Cannot cancel");
+    });
+
+    test("throws for FAILED item", async () => {
+      const itemId = await createItemInDb("FAILED");
+      await expect(orchestrator.cancel(itemId)).rejects.toThrow("Cannot cancel");
+    });
+
+    test("throws for non-existent item", async () => {
+      await expect(orchestrator.cancel("nonexistent")).rejects.toThrow("not found");
+    });
+  });
+
+  describe("retry", () => {
+    async function createItemInDb(status: string, overrides: any = {}) {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+        status,
+        stepContext: null,
+        attempts: 3,
+        maxAttempts: 5,
+        currentStep: null,
+        lastError: "previous error",
+        nextRetryAt: null,
+        skipUntil: null,
+        progress: 50,
+        downloadId: null,
+        encodingJobId: null,
+        cooldownEndsAt: null,
+        discoveredAt: null,
+        completedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+      });
+      return id;
+    }
+
+    test("resets FAILED item to PENDING", async () => {
+      const itemId = await createItemInDb("FAILED");
+      const updated = await orchestrator.retry(itemId);
+      expect(updated.status).toBe("PENDING");
+      expect(updated.attempts).toBe(0);
+      expect(updated.lastError).toBeNull();
+      expect(updated.progress).toBe(0);
+    });
+
+    test("preserves selectedRelease in stepContext on retry", async () => {
+      const itemId = await createItemInDb("FAILED", {
+        stepContext: {
+          selectedRelease: { title: "Inception.2010.1080p" },
+          alternativeReleases: [{ title: "alt" }],
+          download: { torrentHash: "abc" },
+        },
+      });
+
+      const updated = await orchestrator.retry(itemId);
+      const context = updated.stepContext as Record<string, unknown>;
+      expect(context.selectedRelease).toBeDefined();
+      expect(context.qualityMet).toBe(true);
+      // download data should be cleared
+      expect(context.download).toBeUndefined();
+    });
+
+    test("throws for non-FAILED item", async () => {
+      const itemId = await createItemInDb("DOWNLOADING");
+      await expect(orchestrator.retry(itemId)).rejects.toThrow("Cannot retry");
+    });
+
+    test("throws for COMPLETED item", async () => {
+      const itemId = await createItemInDb("COMPLETED");
+      await expect(orchestrator.retry(itemId)).rejects.toThrow("Cannot retry");
+    });
+
+    test("throws for non-existent item", async () => {
+      await expect(orchestrator.retry("nonexistent")).rejects.toThrow("not found");
+    });
+  });
+
+  describe("getItemsForProcessing", () => {
+    test("filters out items with future nextRetryAt", async () => {
+      const id1 = crypto.randomUUID();
+      const id2 = crypto.randomUUID();
+
+      mockPrisma._stores.processingItem.set(id1, {
+        id: id1,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Ready",
+        status: "DOWNLOADING",
+        nextRetryAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockPrisma._stores.processingItem.set(id2, {
+        id: id2,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 2,
+        title: "Not ready",
+        status: "DOWNLOADING",
+        nextRetryAt: new Date(Date.now() + 300000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const items = await orchestrator.getItemsForProcessing("DOWNLOADING");
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe(id1);
+    });
+
+    test("includes items with past nextRetryAt", async () => {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Past retry",
+        status: "DOWNLOADING",
+        nextRetryAt: new Date(Date.now() - 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const items = await orchestrator.getItemsForProcessing("DOWNLOADING");
+      expect(items).toHaveLength(1);
+    });
+  });
+
+  describe("updateProgress", () => {
+    test("updates progress value", async () => {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+        status: "DOWNLOADING",
+        progress: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const updated = await orchestrator.updateProgress(id, 75);
+      expect(updated.progress).toBe(75);
+    });
+  });
+
+  describe("updateContext", () => {
+    test("merges context into stepContext", async () => {
+      const id = crypto.randomUUID();
+      mockPrisma._stores.processingItem.set(id, {
+        id,
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+        status: "DOWNLOADING",
+        stepContext: { existing: true },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const updated = await orchestrator.updateContext(id, { newField: "value" });
+      const context = updated.stepContext as Record<string, unknown>;
+      expect(context.existing).toBe(true);
+      expect(context.newField).toBe("value");
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/ProcessingItemRepository.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/ProcessingItemRepository.test.ts
@@ -1,0 +1,422 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createMockPrisma } from "../../../__tests__/setup.js";
+
+const mockPrisma = createMockPrisma();
+
+// Add missing update and delete methods to processingItem mock
+const processingItemStore = mockPrisma._stores.processingItem;
+
+mockPrisma.processingItem.update = mock(
+  async ({ where, data }: { where: { id: string }; data: any }) => {
+    const record = processingItemStore.get(where.id);
+    if (!record) throw new Error(`Record ${where.id} not found`);
+
+    const updateData = { ...data };
+    // Handle Prisma increment syntax
+    if (data.attempts?.increment) {
+      updateData.attempts = (record.attempts || 0) + data.attempts.increment;
+    }
+    // Handle relation connect/disconnect (simplify for tests)
+    if (data.download) {
+      if (data.download.connect) {
+        updateData.downloadId = data.download.connect.id;
+      } else if (data.download.disconnect) {
+        updateData.downloadId = null;
+      }
+      delete updateData.download;
+    }
+
+    const updated = { ...record, ...updateData, updatedAt: new Date() };
+    processingItemStore.set(where.id, updated);
+    return updated;
+  }
+);
+
+mockPrisma.processingItem.delete = mock(async ({ where }: { where: { id: string } }) => {
+  const record = processingItemStore.get(where.id);
+  processingItemStore.delete(where.id);
+  return record;
+});
+
+mock.module("../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+const { ProcessingItemRepository } = await import("../ProcessingItemRepository.js");
+
+describe("ProcessingItemRepository", () => {
+  let repo: InstanceType<typeof ProcessingItemRepository>;
+
+  beforeEach(() => {
+    repo = new ProcessingItemRepository();
+    mockPrisma._clear();
+  });
+
+  afterEach(() => {
+    mockPrisma._clear();
+  });
+
+  describe("create", () => {
+    test("creates item with PENDING status by default", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 27205,
+        title: "Inception",
+        year: 2010,
+      });
+
+      expect(item.status).toBe("PENDING");
+      expect(item.tmdbId).toBe(27205);
+      expect(item.title).toBe("Inception");
+      expect(item.year).toBe(2010);
+      expect(item.type).toBe("MOVIE");
+      expect(item.requestId).toBe("req-1");
+    });
+
+    test("creates item with default maxAttempts of 5", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+      expect(item.maxAttempts).toBe(5);
+    });
+
+    test("creates item with custom status and maxAttempts", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+        status: "SEARCHING",
+        maxAttempts: 10,
+      });
+      expect(item.status).toBe("SEARCHING");
+      expect(item.maxAttempts).toBe(10);
+    });
+
+    test("creates EPISODE with season and episode", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "EPISODE",
+        tmdbId: 1396,
+        title: "Pilot",
+        season: 1,
+        episode: 1,
+      });
+      expect(item.type).toBe("EPISODE");
+      expect(item.season).toBe(1);
+      expect(item.episode).toBe(1);
+    });
+  });
+
+  describe("createMany", () => {
+    test("creates multiple items", async () => {
+      const items = await repo.createMany([
+        { requestId: "req-1", type: "EPISODE", tmdbId: 1396, title: "Ep 1", season: 1, episode: 1 },
+        { requestId: "req-1", type: "EPISODE", tmdbId: 1396, title: "Ep 2", season: 1, episode: 2 },
+        { requestId: "req-1", type: "EPISODE", tmdbId: 1396, title: "Ep 3", season: 1, episode: 3 },
+      ]);
+
+      expect(items).toHaveLength(3);
+      expect(items[0].title).toBe("Ep 1");
+      expect(items[2].episode).toBe(3);
+    });
+  });
+
+  describe("findById", () => {
+    test("returns item when found", async () => {
+      const created = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+      const found = await repo.findById(created.id);
+      expect(found).toBeDefined();
+      expect(found?.id).toBe(created.id);
+    });
+
+    test("returns null when not found", async () => {
+      const found = await repo.findById("nonexistent");
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("findByRequestId", () => {
+    test("returns all items for a request", async () => {
+      await repo.create({ requestId: "req-1", type: "EPISODE", tmdbId: 1, title: "Ep 1" });
+      await repo.create({ requestId: "req-1", type: "EPISODE", tmdbId: 1, title: "Ep 2" });
+      await repo.create({ requestId: "req-2", type: "MOVIE", tmdbId: 2, title: "Other" });
+
+      const items = await repo.findByRequestId("req-1");
+      expect(items).toHaveLength(2);
+    });
+
+    test("returns empty array for non-existent request", async () => {
+      const items = await repo.findByRequestId("nonexistent");
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe("findByStatus", () => {
+    test("filters by status", async () => {
+      await repo.create({ requestId: "req-1", type: "MOVIE", tmdbId: 1, title: "Pending" });
+      const searching = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 2,
+        title: "Searching",
+        status: "SEARCHING",
+      });
+
+      const results = await repo.findByStatus("SEARCHING");
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(searching.id);
+    });
+  });
+
+  describe("updateStatus", () => {
+    test("updates status", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStatus(item.id, "SEARCHING");
+      expect(updated.status).toBe("SEARCHING");
+    });
+
+    test("sets completedAt for COMPLETED status", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStatus(item.id, "COMPLETED");
+      expect(updated.completedAt).toBeDefined();
+    });
+
+    test("sets completedAt for FAILED status", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStatus(item.id, "FAILED", {
+        lastError: "something failed",
+      });
+      expect(updated.completedAt).toBeDefined();
+      expect(updated.lastError).toBe("something failed");
+    });
+
+    test("sets completedAt for CANCELLED status", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStatus(item.id, "CANCELLED");
+      expect(updated.completedAt).toBeDefined();
+    });
+
+    test("does not set completedAt for non-terminal status", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStatus(item.id, "DOWNLOADING");
+      expect(updated.completedAt).toBeUndefined();
+    });
+
+    test("updates with additional data fields", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStatus(item.id, "SEARCHING", {
+        currentStep: "search",
+        progress: 50,
+        stepContext: { searchStarted: true } as any,
+      });
+
+      expect(updated.currentStep).toBe("search");
+      expect(updated.progress).toBe(50);
+    });
+  });
+
+  describe("incrementAttempts", () => {
+    test("increments attempts counter", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      // The mock stores don't support the increment syntax like the real Prisma
+      // So this tests the call happens without error
+      const updated = await repo.incrementAttempts(item.id, new Date(Date.now() + 60000));
+      expect(updated).toBeDefined();
+    });
+  });
+
+  describe("updateProgress", () => {
+    test("clamps progress to 0-100", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateProgress(item.id, 150);
+      expect(updated.progress).toBe(100);
+
+      const updated2 = await repo.updateProgress(item.id, -10);
+      expect(updated2.progress).toBe(0);
+    });
+
+    test("sets valid progress", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateProgress(item.id, 75);
+      expect(updated.progress).toBe(75);
+    });
+  });
+
+  describe("updateStepContext", () => {
+    test("merges new data into existing stepContext", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      // Set initial context
+      await mockPrisma.processingItem.update({
+        where: { id: item.id },
+        data: { stepContext: { key1: "value1" } },
+      });
+
+      const updated = await repo.updateStepContext(item.id, { key2: "value2" });
+      const context = updated.stepContext as Record<string, unknown>;
+      expect(context.key1).toBe("value1");
+      expect(context.key2).toBe("value2");
+    });
+
+    test("creates new context when stepContext is null", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      const updated = await repo.updateStepContext(item.id, { newKey: "newValue" });
+      const context = updated.stepContext as Record<string, unknown>;
+      expect(context.newKey).toBe("newValue");
+    });
+
+    test("throws when item not found", async () => {
+      await expect(repo.updateStepContext("nonexistent", { key: "value" })).rejects.toThrow(
+        "ProcessingItem nonexistent not found"
+      );
+    });
+  });
+
+  describe("delete", () => {
+    test("removes item", async () => {
+      const item = await repo.create({
+        requestId: "req-1",
+        type: "MOVIE",
+        tmdbId: 1,
+        title: "Test",
+      });
+
+      await repo.delete(item.id);
+      const found = await repo.findById(item.id);
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("getRequestStats", () => {
+    test("returns correct statistics", async () => {
+      // Create items in various states
+      await repo.create({ requestId: "req-1", type: "EPISODE", tmdbId: 1, title: "Ep 1" });
+      await repo.create({
+        requestId: "req-1",
+        type: "EPISODE",
+        tmdbId: 1,
+        title: "Ep 2",
+        status: "COMPLETED",
+      });
+      await repo.create({
+        requestId: "req-1",
+        type: "EPISODE",
+        tmdbId: 1,
+        title: "Ep 3",
+        status: "FAILED",
+      });
+      await repo.create({
+        requestId: "req-1",
+        type: "EPISODE",
+        tmdbId: 1,
+        title: "Ep 4",
+        status: "DOWNLOADING",
+      });
+      await repo.create({
+        requestId: "req-1",
+        type: "EPISODE",
+        tmdbId: 1,
+        title: "Ep 5",
+        status: "ENCODING",
+      });
+
+      const stats = await repo.getRequestStats("req-1");
+      expect(stats.total).toBe(5);
+      expect(stats.completed).toBe(1);
+      expect(stats.failed).toBe(1);
+      expect(stats.pending).toBe(1);
+      expect(stats.inProgress).toBe(2);
+    });
+
+    test("returns zeros for non-existent request", async () => {
+      const stats = await repo.getRequestStats("nonexistent");
+      expect(stats.total).toBe(0);
+      expect(stats.completed).toBe(0);
+      expect(stats.failed).toBe(0);
+      expect(stats.pending).toBe(0);
+      expect(stats.inProgress).toBe(0);
+    });
+  });
+
+  describe("updateRequestAggregates", () => {
+    test("is a no-op (deprecated)", async () => {
+      await expect(repo.updateRequestAggregates("req-1")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/SmartRetryStrategy.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/SmartRetryStrategy.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ProcessingItem } from "@prisma/client";
+import { createMockPrisma } from "../../../__tests__/setup.js";
+import { ErrorType } from "../RetryStrategy.js";
+
+const mockPrisma = createMockPrisma();
+mock.module("../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+// Add missing stores to mock
+const circuitBreakerStore = new Map<string, any>();
+const settingsStore = new Map<string, any>();
+
+mockPrisma.circuitBreaker = {
+  findUnique: mock(async ({ where }: { where: { service: string } }) => {
+    return circuitBreakerStore.get(where.service) || null;
+  }),
+  create: mock(async ({ data }: { data: any }) => {
+    const record = { ...data, createdAt: new Date(), updatedAt: new Date() };
+    circuitBreakerStore.set(data.service, record);
+    return record;
+  }),
+  update: mock(async ({ where, data }: { where: { service: string }; data: any }) => {
+    const record = circuitBreakerStore.get(where.service);
+    if (!record) throw new Error(`CircuitBreaker ${where.service} not found`);
+    const updated = { ...record, ...data, updatedAt: new Date() };
+    circuitBreakerStore.set(where.service, updated);
+    return updated;
+  }),
+  findMany: mock(async () => Array.from(circuitBreakerStore.values())),
+};
+
+mockPrisma.settings = {
+  findUnique: mock(async ({ where }: { where: { id: string } }) => {
+    return settingsStore.get(where.id) || null;
+  }),
+};
+
+// Import after mocking
+const { SmartRetryStrategy } = await import("../SmartRetryStrategy.js");
+
+function createItem(overrides: Partial<ProcessingItem> = {}): ProcessingItem {
+  return {
+    id: "item-1",
+    requestId: "req-1",
+    type: "MOVIE",
+    tmdbId: 27205,
+    title: "Inception",
+    year: 2010,
+    season: null,
+    episode: null,
+    status: "DOWNLOADING",
+    currentStep: null,
+    stepContext: null,
+    checkpoint: null,
+    errorHistory: null,
+    attempts: 0,
+    maxAttempts: 5,
+    lastError: null,
+    nextRetryAt: null,
+    skipUntil: null,
+    progress: 0,
+    lastProgressUpdate: null,
+    lastProgressValue: null,
+    downloadId: null,
+    encodingJobId: null,
+    sourceFilePath: null,
+    downloadedAt: null,
+    encodedAt: null,
+    deliveredAt: null,
+    airDate: null,
+    discoveredAt: null,
+    cooldownEndsAt: null,
+    allSearchResults: null,
+    completedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as ProcessingItem;
+}
+
+describe("SmartRetryStrategy", () => {
+  let strategy: InstanceType<typeof SmartRetryStrategy>;
+
+  beforeEach(() => {
+    strategy = new SmartRetryStrategy();
+    circuitBreakerStore.clear();
+    settingsStore.clear();
+  });
+
+  afterEach(() => {
+    circuitBreakerStore.clear();
+    settingsStore.clear();
+  });
+
+  describe("classifyError", () => {
+    test("classifies NETWORK errors", () => {
+      // Note: classifyError does NOT lowercase string inputs, only Error.message
+      expect(strategy.classifyError("econnrefused")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("enotfound")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("etimedout")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("connection lost")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("connection refused")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("network error")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("socket hang up")).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError("connection reset")).toBe(ErrorType.NETWORK);
+    });
+
+    test("classifies TIMEOUT errors", () => {
+      expect(strategy.classifyError("timeout")).toBe(ErrorType.TIMEOUT);
+      expect(strategy.classifyError("timed out")).toBe(ErrorType.TIMEOUT);
+      expect(strategy.classifyError("Request timed out")).toBe(ErrorType.TIMEOUT);
+    });
+
+    test("classifies RATE_LIMIT errors", () => {
+      expect(strategy.classifyError("429")).toBe(ErrorType.RATE_LIMIT);
+      expect(strategy.classifyError("rate limit")).toBe(ErrorType.RATE_LIMIT);
+      expect(strategy.classifyError("too many requests")).toBe(ErrorType.RATE_LIMIT);
+    });
+
+    test("classifies TRANSIENT errors", () => {
+      expect(strategy.classifyError("503")).toBe(ErrorType.TRANSIENT);
+      expect(strategy.classifyError("502")).toBe(ErrorType.TRANSIENT);
+      expect(strategy.classifyError("504")).toBe(ErrorType.TRANSIENT);
+      expect(strategy.classifyError("service unavailable")).toBe(ErrorType.TRANSIENT);
+      expect(strategy.classifyError("temporarily unavailable")).toBe(ErrorType.TRANSIENT);
+    });
+
+    test("classifies PERMANENT errors", () => {
+      expect(strategy.classifyError("404")).toBe(ErrorType.PERMANENT);
+      expect(strategy.classifyError("not found")).toBe(ErrorType.PERMANENT);
+      expect(strategy.classifyError("invalid")).toBe(ErrorType.PERMANENT);
+      expect(strategy.classifyError("forbidden")).toBe(ErrorType.PERMANENT);
+      expect(strategy.classifyError("unauthorized")).toBe(ErrorType.PERMANENT);
+      expect(strategy.classifyError("no releases found")).toBe(ErrorType.PERMANENT);
+    });
+
+    test("classifies unknown errors as TRANSIENT", () => {
+      expect(strategy.classifyError("some random error")).toBe(ErrorType.TRANSIENT);
+      expect(strategy.classifyError("unexpected failure")).toBe(ErrorType.TRANSIENT);
+    });
+
+    test("classifies Error objects", () => {
+      expect(strategy.classifyError(new Error("ECONNREFUSED"))).toBe(ErrorType.NETWORK);
+      expect(strategy.classifyError(new Error("429 Too Many Requests"))).toBe(ErrorType.RATE_LIMIT);
+    });
+  });
+
+  describe("decide", () => {
+    test("max attempts reached for non-SEARCHING status returns no retry", async () => {
+      const item = createItem({ attempts: 5, maxAttempts: 5, status: "DOWNLOADING" });
+      const decision = await strategy.decide(item, "network error");
+      expect(decision.shouldRetry).toBe(false);
+      expect(decision.reason).toContain("Max attempts");
+    });
+
+    test("permanent error for non-SEARCHING status returns no retry", async () => {
+      const item = createItem({ status: "DOWNLOADING" });
+      const decision = await strategy.decide(item, "404 not found");
+      expect(decision.shouldRetry).toBe(false);
+      expect(decision.reason).toContain("Permanent error");
+    });
+
+    test("SEARCHING status retries indefinitely regardless of max attempts", async () => {
+      settingsStore.set("default", { searchRetryIntervalHours: 6 });
+      const item = createItem({ attempts: 100, maxAttempts: 5, status: "SEARCHING" });
+      const decision = await strategy.decide(item, "no releases found");
+      expect(decision.shouldRetry).toBe(true);
+      expect(decision.useSkipUntil).toBe(false);
+    });
+
+    test("SEARCHING with not found uses search retry interval", async () => {
+      settingsStore.set("default", { searchRetryIntervalHours: 12 });
+      const item = createItem({ status: "SEARCHING" });
+      const decision = await strategy.decide(item, "no releases found");
+      expect(decision.shouldRetry).toBe(true);
+      expect(decision.retryAt).toBeDefined();
+      const hoursAway = (decision.retryAt!.getTime() - Date.now()) / (1000 * 60 * 60);
+      expect(hoursAway).toBeGreaterThan(11);
+      expect(hoursAway).toBeLessThan(13);
+    });
+
+    test("SEARCHING defaults to 6 hours when no settings", async () => {
+      const item = createItem({ status: "SEARCHING" });
+      const decision = await strategy.decide(item, "no releases found");
+      expect(decision.shouldRetry).toBe(true);
+      const hoursAway = (decision.retryAt!.getTime() - Date.now()) / (1000 * 60 * 60);
+      expect(hoursAway).toBeGreaterThan(5);
+      expect(hoursAway).toBeLessThan(7);
+    });
+
+    test("transient error returns retry with backoff", async () => {
+      const item = createItem({ attempts: 1, status: "DOWNLOADING" });
+      const decision = await strategy.decide(item, "503 service unavailable");
+      expect(decision.shouldRetry).toBe(true);
+      expect(decision.useSkipUntil).toBe(false);
+      expect(decision.retryAt).toBeDefined();
+      expect(decision.retryAt?.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    test("network error with circuit breaker open uses skipUntil", async () => {
+      circuitBreakerStore.set("indexer", {
+        service: "indexer",
+        state: "OPEN",
+        failures: 5,
+        lastFailure: new Date(),
+        opensAt: new Date(Date.now() + 300000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const item = createItem({ status: "DOWNLOADING" });
+      const decision = await strategy.decide(item, "econnrefused", "indexer");
+      expect(decision.shouldRetry).toBe(true);
+      expect(decision.useSkipUntil).toBe(true);
+      expect(decision.reason).toContain("unavailable");
+    });
+
+    test("network error with circuit breaker closed records failure", async () => {
+      circuitBreakerStore.set("indexer", {
+        service: "indexer",
+        state: "CLOSED",
+        failures: 0,
+        lastFailure: null,
+        opensAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const item = createItem({ status: "DOWNLOADING" });
+      const decision = await strategy.decide(item, "econnrefused", "indexer");
+      expect(decision.shouldRetry).toBe(true);
+      expect(decision.useSkipUntil).toBe(false);
+    });
+  });
+
+  describe("buildErrorHistory", () => {
+    test("creates new history for item with no history", () => {
+      const item = createItem({ errorHistory: null });
+      const history = strategy.buildErrorHistory(item, "test error", ErrorType.TRANSIENT);
+      expect(history).toHaveLength(1);
+      expect(history[0].error).toBe("test error");
+      expect(history[0].errorType).toBe(ErrorType.TRANSIENT);
+      expect(history[0].attempts).toBe(1);
+      expect(history[0].timestamp).toBeDefined();
+    });
+
+    test("appends to existing history", () => {
+      const existing = [
+        {
+          timestamp: new Date().toISOString(),
+          error: "old error",
+          errorType: ErrorType.NETWORK,
+          attempts: 1,
+        },
+      ];
+      const item = createItem({ errorHistory: existing as any, attempts: 1 });
+      const history = strategy.buildErrorHistory(item, "new error", ErrorType.TIMEOUT);
+      expect(history).toHaveLength(2);
+      expect(history[0].error).toBe("old error");
+      expect(history[1].error).toBe("new error");
+      expect(history[1].attempts).toBe(2);
+    });
+
+    test("caps history at 10 entries", () => {
+      const existing = Array.from({ length: 12 }, (_, i) => ({
+        timestamp: new Date().toISOString(),
+        error: `error-${i}`,
+        errorType: ErrorType.TRANSIENT,
+        attempts: i + 1,
+      }));
+      const item = createItem({ errorHistory: existing as any, attempts: 12 });
+      const history = strategy.buildErrorHistory(item, "newest error", ErrorType.NETWORK);
+      expect(history).toHaveLength(10);
+      expect(history[history.length - 1].error).toBe("newest error");
+    });
+
+    test("handles Error objects", () => {
+      const item = createItem();
+      const history = strategy.buildErrorHistory(
+        item,
+        new Error("something broke"),
+        ErrorType.TRANSIENT
+      );
+      expect(history[0].error).toBe("Error: something broke");
+    });
+  });
+
+  describe("formatError", () => {
+    test("returns string errors as-is", () => {
+      expect(strategy.formatError("test error")).toBe("test error");
+    });
+
+    test("formats Error objects", () => {
+      expect(strategy.formatError(new Error("test"))).toBe("Error: test");
+    });
+
+    test("formats custom error types", () => {
+      class CustomError extends Error {
+        constructor() {
+          super("custom message");
+          this.name = "CustomError";
+        }
+      }
+      expect(strategy.formatError(new CustomError())).toBe("CustomError: custom message");
+    });
+  });
+
+  describe("recordSuccess", () => {
+    test("records success in circuit breaker when service provided", async () => {
+      circuitBreakerStore.set("test-service", {
+        service: "test-service",
+        state: "CLOSED",
+        failures: 2,
+        lastFailure: new Date(),
+        opensAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await strategy.recordSuccess("test-service");
+      const breaker = circuitBreakerStore.get("test-service");
+      expect(breaker.failures).toBe(0);
+    });
+
+    test("does nothing when no service provided", async () => {
+      await strategy.recordSuccess();
+      // Should not throw
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/SmartRetryStrategy.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/SmartRetryStrategy.test.ts
@@ -177,7 +177,7 @@ describe("SmartRetryStrategy", () => {
       const decision = await strategy.decide(item, "no releases found");
       expect(decision.shouldRetry).toBe(true);
       expect(decision.retryAt).toBeDefined();
-      const hoursAway = (decision.retryAt!.getTime() - Date.now()) / (1000 * 60 * 60);
+      const hoursAway = ((decision.retryAt as Date).getTime() - Date.now()) / (1000 * 60 * 60);
       expect(hoursAway).toBeGreaterThan(11);
       expect(hoursAway).toBeLessThan(13);
     });
@@ -186,7 +186,7 @@ describe("SmartRetryStrategy", () => {
       const item = createItem({ status: "SEARCHING" });
       const decision = await strategy.decide(item, "no releases found");
       expect(decision.shouldRetry).toBe(true);
-      const hoursAway = (decision.retryAt!.getTime() - Date.now()) / (1000 * 60 * 60);
+      const hoursAway = ((decision.retryAt as Date).getTime() - Date.now()) / (1000 * 60 * 60);
       expect(hoursAway).toBeGreaterThan(5);
       expect(hoursAway).toBeLessThan(7);
     });

--- a/packages/server/src/services/pipeline/__tests__/StateMachine.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/StateMachine.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+import type { ProcessingStatus } from "@prisma/client";
+import { StateMachine, StateTransitionError } from "../StateMachine.js";
+
+const sm = new StateMachine();
+
+const PIPELINE_ORDER: ProcessingStatus[] = [
+  "PENDING",
+  "SEARCHING",
+  "FOUND",
+  "DISCOVERED",
+  "DOWNLOADING",
+  "DOWNLOADED",
+  "ENCODING",
+  "ENCODED",
+  "DELIVERING",
+  "COMPLETED",
+];
+
+const TERMINAL_STATES: ProcessingStatus[] = ["COMPLETED", "FAILED", "CANCELLED"];
+
+const NON_TERMINAL_STATES: ProcessingStatus[] = [
+  "PENDING",
+  "SEARCHING",
+  "FOUND",
+  "DISCOVERED",
+  "DOWNLOADING",
+  "DOWNLOADED",
+  "ENCODING",
+  "ENCODED",
+  "DELIVERING",
+];
+
+describe("StateMachine", () => {
+  describe("canTransition", () => {
+    describe("forward transitions", () => {
+      test("allows all sequential forward transitions", () => {
+        for (let i = 0; i < PIPELINE_ORDER.length - 1; i++) {
+          const from = PIPELINE_ORDER[i];
+          const to = PIPELINE_ORDER[i + 1];
+          expect(sm.canTransition(from, to)).toBe(true);
+        }
+      });
+
+      test("allows skip-ahead transitions", () => {
+        expect(sm.canTransition("PENDING", "DOWNLOADING")).toBe(true);
+        expect(sm.canTransition("SEARCHING", "DOWNLOADED")).toBe(true);
+        expect(sm.canTransition("PENDING", "COMPLETED")).toBe(true);
+        expect(sm.canTransition("FOUND", "ENCODING")).toBe(true);
+      });
+
+      test("allows same-state transitions for non-terminal statuses", () => {
+        for (const status of NON_TERMINAL_STATES) {
+          expect(sm.canTransition(status, status)).toBe(true);
+        }
+      });
+
+      test("blocks same-state transition for COMPLETED (terminal)", () => {
+        expect(sm.canTransition("COMPLETED", "COMPLETED")).toBe(false);
+      });
+    });
+
+    describe("terminal state transitions", () => {
+      test("allows transition to FAILED from any non-terminal state", () => {
+        for (const status of NON_TERMINAL_STATES) {
+          expect(sm.canTransition(status, "FAILED")).toBe(true);
+        }
+      });
+
+      test("allows transition to CANCELLED from any non-terminal state", () => {
+        for (const status of NON_TERMINAL_STATES) {
+          expect(sm.canTransition(status, "CANCELLED")).toBe(true);
+        }
+      });
+
+      test("blocks transitions out of COMPLETED", () => {
+        for (const to of [...PIPELINE_ORDER, ...TERMINAL_STATES]) {
+          expect(sm.canTransition("COMPLETED", to)).toBe(false);
+        }
+      });
+
+      test("blocks transitions out of CANCELLED", () => {
+        for (const to of [...PIPELINE_ORDER, ...TERMINAL_STATES]) {
+          expect(sm.canTransition("CANCELLED", to)).toBe(false);
+        }
+      });
+    });
+
+    describe("retry transitions", () => {
+      test("allows FAILED -> PENDING (retry)", () => {
+        expect(sm.canTransition("FAILED", "PENDING")).toBe(true);
+      });
+
+      test("blocks FAILED to any other status", () => {
+        const otherStatuses = PIPELINE_ORDER.filter((s) => s !== "PENDING");
+        for (const to of otherStatuses) {
+          expect(sm.canTransition("FAILED", to)).toBe(false);
+        }
+      });
+    });
+
+    describe("backward transitions", () => {
+      test("blocks backward transitions", () => {
+        expect(sm.canTransition("DOWNLOADING", "SEARCHING")).toBe(false);
+        expect(sm.canTransition("ENCODING", "DOWNLOADING")).toBe(false);
+        expect(sm.canTransition("DELIVERING", "PENDING")).toBe(false);
+        expect(sm.canTransition("ENCODED", "FOUND")).toBe(false);
+      });
+    });
+  });
+
+  describe("transition", () => {
+    test("returns target status on valid transition", () => {
+      expect(sm.transition("PENDING", "SEARCHING")).toBe("SEARCHING");
+      expect(sm.transition("SEARCHING", "FOUND")).toBe("FOUND");
+      expect(sm.transition("FAILED", "PENDING")).toBe("PENDING");
+    });
+
+    test("throws StateTransitionError on invalid transition", () => {
+      expect(() => sm.transition("COMPLETED", "PENDING")).toThrow(StateTransitionError);
+      expect(() => sm.transition("DOWNLOADING", "SEARCHING")).toThrow(StateTransitionError);
+      expect(() => sm.transition("CANCELLED", "PENDING")).toThrow(StateTransitionError);
+    });
+
+    test("error message includes reason for terminal state", () => {
+      try {
+        sm.transition("COMPLETED", "PENDING");
+      } catch (e) {
+        expect(e).toBeInstanceOf(StateTransitionError);
+        expect((e as StateTransitionError).message).toContain("Cannot leave terminal state");
+        expect((e as StateTransitionError).fromStatus).toBe("COMPLETED");
+        expect((e as StateTransitionError).toStatus).toBe("PENDING");
+      }
+    });
+
+    test("error message includes reason for backward transition", () => {
+      try {
+        sm.transition("DOWNLOADING", "SEARCHING");
+      } catch (e) {
+        expect(e).toBeInstanceOf(StateTransitionError);
+        expect((e as StateTransitionError).message).toContain("Cannot move backwards");
+      }
+    });
+
+    test("error message for FAILED going to non-PENDING", () => {
+      try {
+        sm.transition("FAILED", "SEARCHING");
+      } catch (e) {
+        expect(e).toBeInstanceOf(StateTransitionError);
+        expect((e as StateTransitionError).message).toContain(
+          "FAILED can only transition to PENDING"
+        );
+      }
+    });
+  });
+
+  describe("getNextStates", () => {
+    test("returns empty array for COMPLETED", () => {
+      expect(sm.getNextStates("COMPLETED")).toEqual([]);
+    });
+
+    test("returns empty array for CANCELLED", () => {
+      expect(sm.getNextStates("CANCELLED")).toEqual([]);
+    });
+
+    test("returns only PENDING for FAILED", () => {
+      expect(sm.getNextStates("FAILED")).toEqual(["PENDING"]);
+    });
+
+    test("returns all forward states plus FAILED and CANCELLED for PENDING", () => {
+      const next = sm.getNextStates("PENDING");
+      expect(next).toContain("SEARCHING");
+      expect(next).toContain("COMPLETED");
+      expect(next).toContain("FAILED");
+      expect(next).toContain("CANCELLED");
+      expect(next).not.toContain("PENDING");
+    });
+
+    test("returns correct forward states for mid-pipeline status", () => {
+      const next = sm.getNextStates("DOWNLOADING");
+      expect(next).toContain("DOWNLOADED");
+      expect(next).toContain("ENCODING");
+      expect(next).toContain("COMPLETED");
+      expect(next).toContain("FAILED");
+      expect(next).toContain("CANCELLED");
+      expect(next).not.toContain("PENDING");
+      expect(next).not.toContain("SEARCHING");
+      expect(next).not.toContain("FOUND");
+    });
+
+    test("returns only terminal states for DELIVERING", () => {
+      const next = sm.getNextStates("DELIVERING");
+      expect(next).toContain("COMPLETED");
+      expect(next).toContain("FAILED");
+      expect(next).toContain("CANCELLED");
+      expect(next).toHaveLength(3);
+    });
+  });
+
+  describe("isTerminal", () => {
+    test("returns true for terminal states", () => {
+      expect(sm.isTerminal("COMPLETED")).toBe(true);
+      expect(sm.isTerminal("FAILED")).toBe(true);
+      expect(sm.isTerminal("CANCELLED")).toBe(true);
+    });
+
+    test("returns false for non-terminal states", () => {
+      for (const status of NON_TERMINAL_STATES) {
+        expect(sm.isTerminal(status)).toBe(false);
+      }
+    });
+  });
+
+  describe("requiresValidation", () => {
+    test("returns true for states requiring validation", () => {
+      expect(sm.requiresValidation("FOUND")).toBe(true);
+      expect(sm.requiresValidation("DISCOVERED")).toBe(true);
+      expect(sm.requiresValidation("DOWNLOADED")).toBe(true);
+      expect(sm.requiresValidation("ENCODED")).toBe(true);
+    });
+
+    test("returns false for states not requiring validation", () => {
+      expect(sm.requiresValidation("PENDING")).toBe(false);
+      expect(sm.requiresValidation("SEARCHING")).toBe(false);
+      expect(sm.requiresValidation("DOWNLOADING")).toBe(false);
+      expect(sm.requiresValidation("ENCODING")).toBe(false);
+      expect(sm.requiresValidation("DELIVERING")).toBe(false);
+      expect(sm.requiresValidation("COMPLETED")).toBe(false);
+      expect(sm.requiresValidation("FAILED")).toBe(false);
+      expect(sm.requiresValidation("CANCELLED")).toBe(false);
+    });
+  });
+
+  describe("canRetry (allowsRetry)", () => {
+    test("returns true for retryable states", () => {
+      expect(sm.canRetry("SEARCHING")).toBe(true);
+      expect(sm.canRetry("DOWNLOADING")).toBe(true);
+      expect(sm.canRetry("ENCODING")).toBe(true);
+      expect(sm.canRetry("DELIVERING")).toBe(true);
+      expect(sm.canRetry("FAILED")).toBe(true);
+    });
+
+    test("returns false for non-retryable states", () => {
+      expect(sm.canRetry("PENDING")).toBe(false);
+      expect(sm.canRetry("FOUND")).toBe(false);
+      expect(sm.canRetry("DISCOVERED")).toBe(false);
+      expect(sm.canRetry("DOWNLOADED")).toBe(false);
+      expect(sm.canRetry("ENCODED")).toBe(false);
+      expect(sm.canRetry("COMPLETED")).toBe(false);
+      expect(sm.canRetry("CANCELLED")).toBe(false);
+    });
+  });
+
+  describe("getMetadata", () => {
+    test("returns metadata for all statuses", () => {
+      const allStatuses: ProcessingStatus[] = [...PIPELINE_ORDER, "FAILED", "CANCELLED"];
+      for (const status of allStatuses) {
+        const meta = sm.getMetadata(status);
+        expect(meta.description).toBeDefined();
+        expect(typeof meta.isTerminal).toBe("boolean");
+        expect(typeof meta.requiresValidation).toBe("boolean");
+        expect(typeof meta.allowsRetry).toBe("boolean");
+      }
+    });
+  });
+
+  describe("getNextPipelineStatus", () => {
+    test("returns correct natural progression", () => {
+      expect(sm.getNextPipelineStatus("PENDING")).toBe("SEARCHING");
+      expect(sm.getNextPipelineStatus("SEARCHING")).toBe("FOUND");
+      expect(sm.getNextPipelineStatus("FOUND")).toBe("DOWNLOADING");
+      expect(sm.getNextPipelineStatus("DOWNLOADING")).toBe("DOWNLOADED");
+      expect(sm.getNextPipelineStatus("DOWNLOADED")).toBe("ENCODING");
+      expect(sm.getNextPipelineStatus("ENCODING")).toBe("ENCODED");
+      expect(sm.getNextPipelineStatus("ENCODED")).toBe("DELIVERING");
+      expect(sm.getNextPipelineStatus("DELIVERING")).toBe("COMPLETED");
+    });
+
+    test("returns null for terminal states", () => {
+      expect(sm.getNextPipelineStatus("COMPLETED")).toBeNull();
+      expect(sm.getNextPipelineStatus("FAILED")).toBeNull();
+      expect(sm.getNextPipelineStatus("CANCELLED")).toBeNull();
+    });
+
+    test("skips DISCOVERED in natural progression (FOUND -> DOWNLOADING)", () => {
+      expect(sm.getNextPipelineStatus("FOUND")).toBe("DOWNLOADING");
+    });
+  });
+
+  describe("getErrorStatus", () => {
+    test("always returns FAILED", () => {
+      expect(sm.getErrorStatus()).toBe("FAILED");
+    });
+  });
+
+  describe("getCancelledStatus", () => {
+    test("always returns CANCELLED", () => {
+      expect(sm.getCancelledStatus()).toBe("CANCELLED");
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/ValidationFramework.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/ValidationFramework.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, test } from "bun:test";
+import type { ProcessingItem } from "@prisma/client";
+import { ValidationError, ValidationFramework } from "../ValidationFramework.js";
+
+const vf = new ValidationFramework();
+
+function createItem(overrides: Partial<ProcessingItem> = {}): ProcessingItem {
+  return {
+    id: "item-1",
+    requestId: "req-1",
+    type: "MOVIE",
+    tmdbId: 27205,
+    title: "Inception",
+    year: 2010,
+    season: null,
+    episode: null,
+    status: "PENDING",
+    currentStep: null,
+    stepContext: null,
+    checkpoint: null,
+    errorHistory: null,
+    attempts: 0,
+    maxAttempts: 5,
+    lastError: null,
+    nextRetryAt: null,
+    skipUntil: null,
+    progress: 0,
+    lastProgressUpdate: null,
+    lastProgressValue: null,
+    downloadId: null,
+    encodingJobId: null,
+    sourceFilePath: null,
+    downloadedAt: null,
+    encodedAt: null,
+    deliveredAt: null,
+    airDate: null,
+    discoveredAt: null,
+    cooldownEndsAt: null,
+    allSearchResults: null,
+    completedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as ProcessingItem;
+}
+
+describe("ValidationFramework", () => {
+  describe("validateEntry", () => {
+    test("PENDING is always valid", async () => {
+      const result = await vf.validateEntry(createItem(), "PENDING");
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    describe("SEARCHING entry", () => {
+      test("passes with tmdbId and title", async () => {
+        const item = createItem({ tmdbId: 27205, title: "Inception" });
+        const result = await vf.validateEntry(item, "SEARCHING");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails without tmdbId", async () => {
+        const item = createItem({ tmdbId: 0, title: "Inception" });
+        const result = await vf.validateEntry(item, "SEARCHING");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("TMDB ID required for searching");
+      });
+
+      test("fails without title", async () => {
+        const item = createItem({ tmdbId: 27205, title: "" });
+        const result = await vf.validateEntry(item, "SEARCHING");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Title required for searching");
+      });
+
+      test("fails with both missing", async () => {
+        const item = createItem({ tmdbId: 0, title: "" });
+        const result = await vf.validateEntry(item, "SEARCHING");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toHaveLength(2);
+      });
+    });
+
+    describe("FOUND entry", () => {
+      test("passes with selectedRelease in stepContext", async () => {
+        const item = createItem({
+          stepContext: { selectedRelease: { title: "test" } } as any,
+        });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(true);
+      });
+
+      test("passes with selectedPacks in stepContext", async () => {
+        const item = createItem({
+          stepContext: { selectedPacks: [{ title: "test" }] } as any,
+        });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(true);
+      });
+
+      test("passes with existingDownload in stepContext", async () => {
+        const item = createItem({
+          stepContext: { existingDownload: { torrentHash: "abc" } } as any,
+        });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(true);
+      });
+
+      test("passes with alternativeReleases in stepContext", async () => {
+        const item = createItem({
+          stepContext: { alternativeReleases: [{ title: "alt" }] } as any,
+        });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails with no relevant data in stepContext", async () => {
+        const item = createItem({ stepContext: {} as any });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("No release selected from search results");
+      });
+
+      test("fails with null stepContext", async () => {
+        const item = createItem({ stepContext: null });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(false);
+      });
+
+      test("fails with empty alternativeReleases array", async () => {
+        const item = createItem({
+          stepContext: { alternativeReleases: [] } as any,
+        });
+        const result = await vf.validateEntry(item, "FOUND");
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe("DISCOVERED entry", () => {
+      test("passes with selectedRelease and cooldownEndsAt", async () => {
+        const item = createItem({
+          stepContext: { selectedRelease: { title: "test" } } as any,
+          cooldownEndsAt: new Date(Date.now() + 60000),
+        });
+        const result = await vf.validateEntry(item, "DISCOVERED");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails without cooldownEndsAt", async () => {
+        const item = createItem({
+          stepContext: { selectedRelease: { title: "test" } } as any,
+          cooldownEndsAt: null,
+        });
+        const result = await vf.validateEntry(item, "DISCOVERED");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Cooldown end time must be set for DISCOVERED status");
+      });
+
+      test("fails without release data", async () => {
+        const item = createItem({
+          stepContext: {} as any,
+          cooldownEndsAt: new Date(),
+        });
+        const result = await vf.validateEntry(item, "DISCOVERED");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain(
+          "No release, packs, or existing download selected for discovery cooldown"
+        );
+      });
+    });
+
+    describe("DOWNLOADING entry", () => {
+      test("is always valid (downloadId optional)", async () => {
+        const item = createItem();
+        const result = await vf.validateEntry(item, "DOWNLOADING");
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe("DOWNLOADED entry", () => {
+      test("passes with sourceFilePath in download context", async () => {
+        const item = createItem({
+          stepContext: { download: { sourceFilePath: "/path/to/file.mkv" } } as any,
+        });
+        const result = await vf.validateEntry(item, "DOWNLOADED");
+        expect(result.valid).toBe(true);
+      });
+
+      test("passes with episodeFiles in download context", async () => {
+        const item = createItem({
+          stepContext: {
+            download: { episodeFiles: [{ path: "/path/ep1.mkv" }] },
+          } as any,
+        });
+        const result = await vf.validateEntry(item, "DOWNLOADED");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails without sourceFilePath or episodeFiles", async () => {
+        const item = createItem({
+          stepContext: { download: {} } as any,
+        });
+        const result = await vf.validateEntry(item, "DOWNLOADED");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Download file path required for downloaded state");
+      });
+
+      test("fails with no download data at all", async () => {
+        const item = createItem({ stepContext: {} as any });
+        const result = await vf.validateEntry(item, "DOWNLOADED");
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe("ENCODING entry", () => {
+      test("passes with download sourceFilePath", async () => {
+        const item = createItem({
+          stepContext: { download: { sourceFilePath: "/path/file.mkv" } } as any,
+        });
+        const result = await vf.validateEntry(item, "ENCODING");
+        expect(result.valid).toBe(true);
+      });
+
+      test("passes with download episodeFiles", async () => {
+        const item = createItem({
+          stepContext: {
+            download: { episodeFiles: [{ path: "/ep.mkv" }] },
+          } as any,
+        });
+        const result = await vf.validateEntry(item, "ENCODING");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails without download data", async () => {
+        const item = createItem({ stepContext: {} as any });
+        const result = await vf.validateEntry(item, "ENCODING");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Download data required for encoding");
+      });
+    });
+
+    describe("ENCODED entry", () => {
+      test("passes with encodedFiles containing path", async () => {
+        const item = createItem({
+          stepContext: {
+            encode: { encodedFiles: [{ path: "/encoded.mkv" }] },
+          } as any,
+        });
+        const result = await vf.validateEntry(item, "ENCODED");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails with empty encodedFiles", async () => {
+        const item = createItem({
+          stepContext: { encode: { encodedFiles: [] } } as any,
+        });
+        const result = await vf.validateEntry(item, "ENCODED");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Encoded file path required for encoded state");
+      });
+
+      test("fails with no encode data", async () => {
+        const item = createItem({ stepContext: {} as any });
+        const result = await vf.validateEntry(item, "ENCODED");
+        expect(result.valid).toBe(false);
+      });
+
+      test("fails when first file has no path", async () => {
+        const item = createItem({
+          stepContext: {
+            encode: { encodedFiles: [{ size: 100 }] },
+          } as any,
+        });
+        const result = await vf.validateEntry(item, "ENCODED");
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe("DELIVERING entry", () => {
+      test("passes with encodedFiles", async () => {
+        const item = createItem({
+          stepContext: {
+            encode: { encodedFiles: [{ path: "/encoded.mkv" }] },
+          } as any,
+        });
+        const result = await vf.validateEntry(item, "DELIVERING");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails without encodedFiles", async () => {
+        const item = createItem({ stepContext: {} as any });
+        const result = await vf.validateEntry(item, "DELIVERING");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Encoded file path required for delivery");
+      });
+    });
+
+    describe("COMPLETED entry", () => {
+      test("passes with deliveryResults", async () => {
+        const item = createItem({
+          stepContext: { deliveryResults: [{ serverId: "s1" }] } as any,
+        });
+        const result = await vf.validateEntry(item, "COMPLETED");
+        expect(result.valid).toBe(true);
+      });
+
+      test("fails without deliveryResults", async () => {
+        const item = createItem({ stepContext: {} as any });
+        const result = await vf.validateEntry(item, "COMPLETED");
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Delivery results required for completion");
+      });
+    });
+
+    describe("FAILED and CANCELLED entry", () => {
+      test("FAILED is always valid", async () => {
+        const result = await vf.validateEntry(createItem(), "FAILED");
+        expect(result.valid).toBe(true);
+      });
+
+      test("CANCELLED is always valid", async () => {
+        const result = await vf.validateEntry(createItem(), "CANCELLED");
+        expect(result.valid).toBe(true);
+      });
+    });
+  });
+
+  describe("validateExit", () => {
+    test("PENDING exit has no validation", async () => {
+      const result = await vf.validateExit(createItem(), "PENDING");
+      expect(result.valid).toBe(true);
+    });
+
+    test("SEARCHING exit requires search results", async () => {
+      const item = createItem({ stepContext: {} as any });
+      const result = await vf.validateExit(item, "SEARCHING");
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("No search results found");
+    });
+
+    test("SEARCHING exit passes with selectedRelease", async () => {
+      const item = createItem({
+        stepContext: { selectedRelease: { title: "test" } } as any,
+      });
+      const result = await vf.validateExit(item, "SEARCHING");
+      expect(result.valid).toBe(true);
+    });
+
+    test("DOWNLOADING exit requires complete download data", async () => {
+      const item = createItem({ stepContext: { download: {} } as any });
+      const result = await vf.validateExit(item, "DOWNLOADING");
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Download not marked as complete");
+    });
+
+    test("DOWNLOADING exit passes with isComplete", async () => {
+      const item = createItem({
+        stepContext: { download: { isComplete: true } } as any,
+      });
+      const result = await vf.validateExit(item, "DOWNLOADING");
+      expect(result.valid).toBe(true);
+    });
+
+    test("DOWNLOADING exit passes with sourceFilePath", async () => {
+      const item = createItem({
+        stepContext: { download: { sourceFilePath: "/path" } } as any,
+      });
+      const result = await vf.validateExit(item, "DOWNLOADING");
+      expect(result.valid).toBe(true);
+    });
+
+    test("ENCODING exit requires encoded files", async () => {
+      const item = createItem({ stepContext: {} as any });
+      const result = await vf.validateExit(item, "ENCODING");
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Encoding not complete - no encoded files found");
+    });
+
+    test("ENCODING exit passes with encoded files", async () => {
+      const item = createItem({
+        stepContext: {
+          encode: { encodedFiles: [{ path: "/out.mkv" }] },
+        } as any,
+      });
+      const result = await vf.validateExit(item, "ENCODING");
+      expect(result.valid).toBe(true);
+    });
+
+    test("DELIVERING exit requires allDeliveriesComplete", async () => {
+      const item = createItem({ stepContext: {} as any });
+      const result = await vf.validateExit(item, "DELIVERING");
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Not all deliveries marked as complete");
+    });
+
+    test("DELIVERING exit passes with allDeliveriesComplete", async () => {
+      const item = createItem({
+        stepContext: { allDeliveriesComplete: true } as any,
+      });
+      const result = await vf.validateExit(item, "DELIVERING");
+      expect(result.valid).toBe(true);
+    });
+
+    test("terminal states have no exit validation", async () => {
+      for (const status of ["COMPLETED", "FAILED", "CANCELLED"] as const) {
+        const result = await vf.validateExit(createItem(), status);
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    test("DISCOVERED exit requires selected release or packs", async () => {
+      const item = createItem({ stepContext: {} as any });
+      const result = await vf.validateExit(item, "DISCOVERED");
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("No release selected");
+    });
+  });
+
+  describe("validateTransition", () => {
+    test("combines entry and exit validation", async () => {
+      const item = createItem({
+        status: "SEARCHING",
+        stepContext: { selectedRelease: { title: "test" } } as any,
+      });
+      const result = await vf.validateTransition(item, "SEARCHING", "FOUND", {
+        stepContext: { selectedRelease: { title: "test" } },
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    test("skips exit validation for FAILED transition", async () => {
+      const item = createItem({
+        status: "SEARCHING",
+        stepContext: {} as any,
+      });
+      const result = await vf.validateTransition(item, "SEARCHING", "FAILED");
+      expect(result.valid).toBe(true);
+    });
+
+    test("skips exit validation for CANCELLED transition", async () => {
+      const item = createItem({
+        status: "ENCODING",
+        stepContext: {} as any,
+      });
+      const result = await vf.validateTransition(item, "ENCODING", "CANCELLED");
+      expect(result.valid).toBe(true);
+    });
+
+    test("returns exit errors when non-terminal", async () => {
+      const item = createItem({
+        status: "SEARCHING",
+        stepContext: {} as any,
+      });
+      const result = await vf.validateTransition(item, "SEARCHING", "FOUND");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("Exit validation failed");
+    });
+
+    test("uses newContext for validation if provided", async () => {
+      const item = createItem({
+        status: "PENDING",
+        stepContext: null,
+        tmdbId: 27205,
+        title: "Inception",
+      });
+      const result = await vf.validateTransition(item, "PENDING", "FOUND", {
+        stepContext: { selectedRelease: { title: "Inception.2010.1080p" } },
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("assertValid", () => {
+    test("does not throw for valid entry", async () => {
+      const item = createItem({ tmdbId: 27205, title: "Inception" });
+      await expect(vf.assertValid(item, "SEARCHING", "entry")).resolves.toBeUndefined();
+    });
+
+    test("throws ValidationError for invalid entry", async () => {
+      const item = createItem({ tmdbId: 0, title: "" });
+      try {
+        await vf.assertValid(item, "SEARCHING", "entry");
+        expect(true).toBe(false); // Should not reach
+      } catch (e) {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as ValidationError).itemId).toBe("item-1");
+        expect((e as ValidationError).status).toBe("SEARCHING");
+        expect((e as ValidationError).validationType).toBe("entry");
+      }
+    });
+
+    test("throws ValidationError for invalid exit", async () => {
+      const item = createItem({ stepContext: {} as any });
+      try {
+        await vf.assertValid(item, "SEARCHING", "exit");
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as ValidationError).validationType).toBe("exit");
+      }
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/steps/DeliverStep.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/steps/DeliverStep.test.ts
@@ -1,0 +1,589 @@
+/**
+ * DeliverStep Unit Tests
+ *
+ * Tests delivery step behavior in isolation without real server transfers
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createMockPrisma } from "../../../../__tests__/setup.js";
+import { assertStepFailure, assertStepSuccess } from "../test-utils/assertions.js";
+import { ContextBuilder } from "../test-utils/context-builder.js";
+
+// Mock Prisma client to prevent database access
+const mockPrisma = createMockPrisma();
+
+// Add libraryItem model to mock prisma (not in default createMockPrisma)
+const libraryItemStore = new Map<string, any>();
+mockPrisma.libraryItem = {
+  upsert: mock(async ({ where, create, update }: { where: any; create: any; update: any }) => {
+    const key = `${where.tmdbId_type_serverId.tmdbId}-${where.tmdbId_type_serverId.type}-${where.tmdbId_type_serverId.serverId}`;
+    const existing = libraryItemStore.get(key);
+    const record = existing
+      ? { ...existing, ...update, updatedAt: new Date() }
+      : { id: key, ...create, createdAt: new Date(), updatedAt: new Date() };
+    libraryItemStore.set(key, record);
+    return record;
+  }),
+  deleteMany: mock(async () => {
+    const count = libraryItemStore.size;
+    libraryItemStore.clear();
+    return { count };
+  }),
+};
+
+mock.module("../../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+// Mock delivery service
+let mockDeliveryService: {
+  deliver: ReturnType<typeof mock>;
+  fileExists: ReturnType<typeof mock>;
+};
+
+mock.module("../../../delivery.js", () => ({
+  getDeliveryService: () => mockDeliveryService,
+}));
+
+// Mock naming service
+let mockNamingService: {
+  getMovieDestinationPath: ReturnType<typeof mock>;
+  getTvDestinationPath: ReturnType<typeof mock>;
+};
+
+mock.module("../../../naming.js", () => ({
+  getNamingService: () => mockNamingService,
+}));
+
+// Mock pipeline orchestrator
+const mockTransitionStatus = mock(async () => ({}));
+
+mock.module("../../PipelineOrchestrator.js", () => ({
+  pipelineOrchestrator: {
+    transitionStatus: mockTransitionStatus,
+  },
+}));
+
+// Mock Bun.file for cleanup operations
+const mockFileExists = mock(() => Promise.resolve(true));
+const mockFileDelete = mock(() => Promise.resolve());
+const originalBunFile = Bun.file;
+
+// Import after mocks are set up
+import { DeliverStep } from "../../steps/DeliverStep.js";
+
+describe("DeliverStep", () => {
+  beforeEach(async () => {
+    mockDeliveryService = {
+      deliver: mock(async () => ({
+        success: true,
+        serverId: "server-1",
+        serverName: "Test Server",
+        localPath: "/tmp/encoded.mkv",
+        remotePath: "/movies/Test Movie (2020)/Test Movie (2020) [1080p AV1].mkv",
+        bytesTransferred: 1024 * 1024 * 100,
+        duration: 30,
+        libraryScanTriggered: true,
+      })),
+      fileExists: mock(async () => false),
+    };
+
+    mockNamingService = {
+      getMovieDestinationPath: mock(
+        () => "/movies/Inception (2010) [tmdb-27205]/Inception (2010) [tmdb-27205] [1080p AV1].mkv"
+      ),
+      getTvDestinationPath: mock(
+        () => "/tv/Breaking Bad (2008)/Season 01/Breaking Bad - S01E01 - Pilot [1080p AV1].mkv"
+      ),
+    };
+
+    // Create test storage servers
+    await mockPrisma.storageServer.create({
+      data: {
+        id: "server-1",
+        name: "Server One",
+        host: "localhost",
+        port: 22,
+        protocol: "SFTP",
+        username: "test",
+        encryptedPassword: "test",
+        pathMovies: "/movies",
+        pathTv: "/tv",
+        maxResolution: "RES_4K",
+        preferredCodec: "AV1",
+        enabled: true,
+      },
+    });
+
+    await mockPrisma.storageServer.create({
+      data: {
+        id: "server-2",
+        name: "Server Two",
+        host: "remote",
+        port: 22,
+        protocol: "SFTP",
+        username: "test",
+        encryptedPassword: "test",
+        pathMovies: "/movies",
+        pathTv: "/tv",
+        maxResolution: "RES_1080P",
+        preferredCodec: "AV1",
+        enabled: true,
+      },
+    });
+
+    // Mock Bun.file for cleanup tests
+    mockFileExists.mockImplementation(() => Promise.resolve(true));
+    mockFileDelete.mockImplementation(() => Promise.resolve());
+
+    // @ts-expect-error - override Bun.file for tests
+    Bun.file = mock((_path: string) => ({
+      exists: mockFileExists,
+      delete: mockFileDelete,
+    }));
+  });
+
+  afterEach(async () => {
+    mockPrisma._clear();
+    libraryItemStore.clear();
+    mockTransitionStatus.mockClear();
+    mockFileExists.mockClear();
+    mockFileDelete.mockClear();
+    (Bun as any).file = originalBunFile;
+  });
+
+  describe("Config Validation", () => {
+    test("should accept undefined config", () => {
+      const step = new DeliverStep();
+      expect(() => step.validateConfig(undefined)).not.toThrow();
+    });
+
+    test("should accept object config", () => {
+      const step = new DeliverStep();
+      expect(() => step.validateConfig({ requireAllServersSuccess: true })).not.toThrow();
+    });
+
+    test("should throw on non-object config", () => {
+      const step = new DeliverStep();
+      expect(() => step.validateConfig("invalid")).toThrow("DeliverStep config must be an object");
+      expect(() => step.validateConfig(42)).toThrow("DeliverStep config must be an object");
+      expect(() => step.validateConfig(true)).toThrow("DeliverStep config must be an object");
+    });
+  });
+
+  describe("No Encoded Files", () => {
+    test("should fail when encode.encodedFiles is missing", async () => {
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-1")
+        .withTargets([{ serverId: "server-1" }])
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, {});
+
+      expect(result.success).toBe(false);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.error).toBe("No encoded files available for delivery");
+    });
+
+    test("should fail when encode.encodedFiles is empty array", async () => {
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-2")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({ encodedFiles: [] })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, {});
+
+      expect(result.success).toBe(false);
+      expect(result.shouldRetry).toBe(false);
+      expect(result.error).toBe("No encoded files available for delivery");
+    });
+  });
+
+  describe("Movie Delivery", () => {
+    test("should generate path via naming service and deliver to servers", async () => {
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-movie")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+
+      // Verify naming service was called
+      expect(mockNamingService.getMovieDestinationPath).toHaveBeenCalled();
+
+      // Verify delivery service was called
+      expect(mockDeliveryService.deliver).toHaveBeenCalled();
+
+      // Verify output data
+      const deliverData = result.data?.deliver as Record<string, unknown>;
+      expect(deliverData).toBeDefined();
+      expect(deliverData.deliveredServers).toEqual(["server-1"]);
+      expect(deliverData.failedServers).toEqual([]);
+      expect(deliverData.completedAt).toBeDefined();
+    });
+  });
+
+  describe("Recovery", () => {
+    test("should skip delivery when all files already exist on servers", async () => {
+      // All files already exist on the target servers
+      mockDeliveryService.fileExists.mockImplementation(async () => true);
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-recovery")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+
+      // Should NOT have called deliver (skipped)
+      expect(mockDeliveryService.deliver).not.toHaveBeenCalled();
+
+      // Verify recovery data
+      const deliverData = result.data?.deliver as Record<string, unknown>;
+      expect(deliverData.recovered).toBe(true);
+      expect(deliverData.deliveredServers).toEqual(["server-1"]);
+      expect(deliverData.failedServers).toEqual([]);
+    });
+  });
+
+  describe("Partial Failure with requireAllServersSuccess=true", () => {
+    test("should return success=true in failure branch when some servers succeed (known bug at line 562)", async () => {
+      // This documents a known bug: when requireAllServersSuccess is true and some
+      // servers fail, the code enters the failure branch (line 516+) but then returns
+      // success = deliveredServers.length > 0 (line 562), which is true when partial
+      // delivery succeeds. This means even though the config requires all servers to
+      // succeed, the final return still reports success if at least one delivered.
+
+      // Server-1 succeeds, server-2 fails
+      let callCount = 0;
+      mockDeliveryService.deliver.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            success: true,
+            serverId: "server-1",
+            serverName: "Server One",
+            localPath: "/tmp/encoded/inception.mkv",
+            remotePath: "/movies/inception.mkv",
+            bytesTransferred: 1024 * 1024,
+            duration: 10,
+            libraryScanTriggered: true,
+          };
+        }
+        return {
+          success: false,
+          serverId: "server-2",
+          serverName: "Server Two",
+          localPath: "/tmp/encoded/inception.mkv",
+          remotePath: "/movies/inception.mkv",
+          bytesTransferred: 0,
+          duration: 0,
+          error: "Connection refused",
+          libraryScanTriggered: false,
+        };
+      });
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-partial-1")
+        .withTargets([{ serverId: "server-1" }, { serverId: "server-2" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1", "server-2"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, { requireAllServersSuccess: true });
+
+      // Known bug: the failure branch (line 562) returns success based on
+      // deliveredServers.length > 0, so partial delivery still returns success=true
+      expect(result.success).toBe(true);
+      expect(result.shouldRetry).toBe(true);
+      expect(result.error).toContain("Delivered to 1 servers, failed 1");
+
+      const deliverData = result.data?.deliver as Record<string, unknown>;
+      expect((deliverData.deliveredServers as string[]).length).toBe(1);
+      expect((deliverData.failedServers as string[]).length).toBe(1);
+    });
+  });
+
+  describe("Partial Failure with requireAllServersSuccess=false", () => {
+    test("should return success=true when some servers succeed and requireAllServersSuccess is false", async () => {
+      // When requireAllServersSuccess is false, partial success is expected.
+      // The success path (line 369) evaluates to true because deliveredServers.length > 0.
+
+      let callCount = 0;
+      mockDeliveryService.deliver.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            success: true,
+            serverId: "server-1",
+            serverName: "Server One",
+            localPath: "/tmp/encoded/inception.mkv",
+            remotePath: "/movies/inception.mkv",
+            bytesTransferred: 1024 * 1024,
+            duration: 10,
+            libraryScanTriggered: true,
+          };
+        }
+        return {
+          success: false,
+          serverId: "server-2",
+          serverName: "Server Two",
+          localPath: "/tmp/encoded/inception.mkv",
+          remotePath: "/movies/inception.mkv",
+          bytesTransferred: 0,
+          duration: 0,
+          error: "Timeout",
+          libraryScanTriggered: false,
+        };
+      });
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-partial-2")
+        .withTargets([{ serverId: "server-1" }, { serverId: "server-2" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1", "server-2"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, { requireAllServersSuccess: false });
+
+      // With requireAllServersSuccess=false, success = deliveredServers.length > 0 -> true
+      // This enters the success branch (line 371)
+      expect(result.success).toBe(true);
+
+      const deliverData = result.data?.deliver as Record<string, unknown>;
+      expect(deliverData.deliveredServers).toEqual(["server-1"]);
+      expect((deliverData.failedServers as any[]).length).toBe(1);
+    });
+  });
+
+  describe("Total Failure", () => {
+    test("should return success=false when no servers succeed", async () => {
+      mockDeliveryService.deliver.mockImplementation(async () => ({
+        success: false,
+        serverId: "server-1",
+        serverName: "Server One",
+        localPath: "/tmp/encoded/inception.mkv",
+        remotePath: "/movies/inception.mkv",
+        bytesTransferred: 0,
+        duration: 0,
+        error: "Disk full",
+        libraryScanTriggered: false,
+      }));
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-fail")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, {});
+
+      assertStepFailure(result, "Failed to deliver to all servers");
+      expect(result.shouldRetry).toBe(true);
+
+      const deliverData = result.data?.deliver as Record<string, unknown>;
+      expect(deliverData.deliveredServers).toEqual([]);
+      expect((deliverData.failedServers as string[]).length).toBe(1);
+    });
+
+    test("should transition episode status to FAILED on total failure", async () => {
+      mockDeliveryService.deliver.mockImplementation(async () => ({
+        success: false,
+        serverId: "server-1",
+        serverName: "Server One",
+        localPath: "/tmp/encoded/ep.mkv",
+        remotePath: "/tv/show.mkv",
+        bytesTransferred: 0,
+        duration: 0,
+        error: "Connection lost",
+        libraryScanTriggered: false,
+      }));
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-fail-ep")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/ep.mkv",
+              targetServerIds: ["server-1"],
+              resolution: "1080p",
+              codec: "AV1",
+              episodeId: "episode-1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      await step.execute(context, {});
+
+      // Should have called transitionStatus for the failed episode
+      expect(mockTransitionStatus).toHaveBeenCalledWith(
+        "episode-1",
+        "FAILED",
+        expect.objectContaining({
+          currentStep: "delivery_failed",
+        })
+      );
+    });
+  });
+
+  describe("File Cleanup", () => {
+    test("should delete encoded files on complete success", async () => {
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-cleanup")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+
+      // Verify Bun.file was called for cleanup
+      expect(mockFileExists).toHaveBeenCalled();
+      expect(mockFileDelete).toHaveBeenCalled();
+    });
+
+    test("should preserve encoded files when some servers failed", async () => {
+      let callCount = 0;
+      mockDeliveryService.deliver.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            success: true,
+            serverId: "server-1",
+            serverName: "Server One",
+            localPath: "/tmp/encoded/inception.mkv",
+            remotePath: "/movies/inception.mkv",
+            bytesTransferred: 1024,
+            duration: 5,
+            libraryScanTriggered: true,
+          };
+        }
+        return {
+          success: false,
+          serverId: "server-2",
+          serverName: "Server Two",
+          localPath: "/tmp/encoded/inception.mkv",
+          remotePath: "/movies/inception.mkv",
+          bytesTransferred: 0,
+          duration: 0,
+          error: "Timeout",
+          libraryScanTriggered: false,
+        };
+      });
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("req-no-cleanup")
+        .withTargets([{ serverId: "server-1" }, { serverId: "server-2" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "profile-1",
+              path: "/tmp/encoded/inception.mkv",
+              targetServerIds: ["server-1", "server-2"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new DeliverStep();
+      // requireAllServersSuccess=false so it enters the success branch with partial failure
+      const result = await step.execute(context, { requireAllServersSuccess: false });
+
+      expect(result.success).toBe(true);
+
+      // Files should NOT be deleted because some servers failed (failedServers.length > 0)
+      expect(mockFileDelete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/steps/DownloadStep.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/steps/DownloadStep.test.ts
@@ -1,0 +1,384 @@
+/**
+ * DownloadStep Unit Tests
+ *
+ * Tests download step behavior in isolation without real qBittorrent calls
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { MediaType, ProcessingStatus } from "@prisma/client";
+import { createMockPrisma } from "../../../../__tests__/setup.js";
+import { MOVIES, TARGETS, TV_SHOWS } from "../fixtures/media.js";
+import { assertStepData, assertStepFailure, assertStepSuccess } from "../test-utils/assertions.js";
+import { ContextBuilder } from "../test-utils/context-builder.js";
+import { cleanupTestData, createTestRequest, createTestServer } from "../test-utils/database.js";
+
+// Mock Prisma client to prevent database access
+const mockPrisma = createMockPrisma();
+mock.module("../../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+// Mock download service (qBittorrent client)
+const mockDownloadService = {
+  createDownload: mock(async () => ({
+    id: "dl-1",
+    torrentHash: "abc123",
+    torrentName: "Test.Download",
+  })),
+  waitForCompletion: mock(async () => ({
+    success: true,
+    progress: {
+      progress: 100,
+      savePath: "/downloads",
+      contentPath: "/downloads/Test.Download",
+      seeds: 10,
+      peers: 5,
+    },
+  })),
+  getProgress: mock(async () => ({
+    progress: 100,
+    savePath: "/downloads",
+    contentPath: "/downloads/Test.Download",
+  })),
+  getMainVideoFile: mock(async () => ({
+    path: "/downloads/Test.Download/movie.mkv",
+    size: 5_000_000_000,
+    name: "movie.mkv",
+  })),
+  getTorrentFiles: mock(async () => []),
+};
+
+mock.module("../../../download.js", () => ({
+  getDownloadService: () => mockDownloadService,
+}));
+
+// Mock download manager
+const mockDownloadManager = {
+  createDownload: mock(async () => ({
+    id: "dl-1",
+    torrentHash: "abc123",
+    torrentName: "Test.Download.1080p",
+  })),
+  createDownloadFromExisting: mock(async () => ({
+    id: "dl-existing",
+    torrentHash: "existing-hash",
+    torrentName: "Existing.Download",
+  })),
+  findExistingMovieDownload: mock(async () => ({ found: false, isComplete: false })),
+  handleStalledDownload: mock(async () => {}),
+};
+
+mock.module("../../../downloadManager.js", () => ({
+  downloadManager: mockDownloadManager,
+}));
+
+// Mock archive utilities
+mock.module("../../../archive.js", () => ({
+  detectRarArchive: () => ({ hasArchive: false, archivePath: null }),
+  extractRar: async () => ({ success: true, extractedFiles: [] }),
+  isSampleFile: () => false,
+}));
+
+// Mock pipeline orchestrator
+mock.module("../../PipelineOrchestrator.js", () => ({
+  pipelineOrchestrator: {
+    transitionStatus: mock(async () => ({})),
+  },
+}));
+
+// Import the step under test AFTER all mock.module calls
+import { DownloadStep } from "../../steps/DownloadStep.js";
+
+describe("DownloadStep", () => {
+  beforeEach(async () => {
+    await createTestServer({
+      id: "test-server-1080p",
+      name: "1080p Test Server",
+      maxResolution: "RES_1080P",
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupTestData();
+    await mockPrisma.storageServer.deleteMany();
+    mockDownloadService.createDownload.mockClear();
+    mockDownloadService.waitForCompletion.mockClear();
+    mockDownloadService.getProgress.mockClear();
+    mockDownloadService.getMainVideoFile.mockClear();
+    mockDownloadService.getTorrentFiles.mockClear();
+    mockDownloadManager.createDownload.mockClear();
+    mockDownloadManager.createDownloadFromExisting.mockClear();
+    mockDownloadManager.findExistingMovieDownload.mockClear();
+    mockDownloadManager.handleStalledDownload.mockClear();
+  });
+
+  describe("Recovery", () => {
+    test("should skip download when context already has sourceFilePath", async () => {
+      const request = await createTestRequest({
+        createExecution: true,
+        ...MOVIES.INCEPTION,
+        targets: TARGETS.SINGLE_1080P_SERVER,
+      });
+
+      const context = new ContextBuilder()
+        .forMovie(MOVIES.INCEPTION.title, MOVIES.INCEPTION.year, MOVIES.INCEPTION.tmdbId)
+        .withRequestId(request.id)
+        .withTargets(TARGETS.SINGLE_1080P_SERVER)
+        .withDownloadResult({
+          torrentHash: "recovered-hash",
+          sourceFilePath: "/downloads/Inception.2010.1080p/movie.mkv",
+        })
+        .build();
+
+      const step = new DownloadStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+      assertStepData(result, "download");
+
+      const downloadData = result.data?.download as Record<string, unknown>;
+      expect(downloadData.sourceFilePath).toBe("/downloads/Inception.2010.1080p/movie.mkv");
+      expect(downloadData.torrentHash).toBe("recovered-hash");
+
+      // Should NOT have created a new download
+      expect(mockDownloadManager.createDownload).not.toHaveBeenCalled();
+      expect(mockDownloadManager.createDownloadFromExisting).not.toHaveBeenCalled();
+    });
+
+    test("should skip download when episode processingItem already has sourceFilePath", async () => {
+      const request = await createTestRequest({
+        createExecution: true,
+        type: MediaType.TV,
+        tmdbId: TV_SHOWS.BREAKING_BAD.tmdbId,
+        title: TV_SHOWS.BREAKING_BAD.title,
+        year: TV_SHOWS.BREAKING_BAD.year,
+        requestedSeasons: [1],
+        targets: TARGETS.SINGLE_1080P_SERVER,
+      });
+
+      // Create a processingItem record with a sourceFilePath already set
+      const processingItem = await mockPrisma.processingItem.create({
+        data: {
+          id: "episode-item-1",
+          requestId: request.id,
+          type: "EPISODE",
+          season: 1,
+          episode: 1,
+          status: ProcessingStatus.DOWNLOADED,
+          sourceFilePath: "/downloads/Breaking.Bad.S01E01.mkv",
+        },
+      });
+
+      const context = new ContextBuilder()
+        .forTvShow(
+          TV_SHOWS.BREAKING_BAD.title,
+          TV_SHOWS.BREAKING_BAD.year,
+          TV_SHOWS.BREAKING_BAD.tmdbId,
+          [1]
+        )
+        .withRequestId(request.id)
+        .withTargets(TARGETS.SINGLE_1080P_SERVER)
+        .build();
+
+      // Set episodeId on context (accessed via index signature)
+      (context as Record<string, unknown>).episodeId = processingItem.id;
+
+      const step = new DownloadStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+      assertStepData(result, "download");
+
+      const downloadData = result.data?.download as Record<string, unknown>;
+      expect(downloadData.sourceFilePath).toBe("/downloads/Breaking.Bad.S01E01.mkv");
+
+      // Should NOT have created a new download
+      expect(mockDownloadManager.createDownload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("No Download Source", () => {
+    test("should fail when neither selectedRelease nor existingDownload is present", async () => {
+      const request = await createTestRequest({
+        createExecution: true,
+        ...MOVIES.INCEPTION,
+        targets: TARGETS.SINGLE_1080P_SERVER,
+      });
+
+      const context = new ContextBuilder()
+        .forMovie(MOVIES.INCEPTION.title, MOVIES.INCEPTION.year, MOVIES.INCEPTION.tmdbId)
+        .withRequestId(request.id)
+        .withTargets(TARGETS.SINGLE_1080P_SERVER)
+        .withSearchResult({})
+        .build();
+
+      const step = new DownloadStep();
+      const result = await step.execute(context, {});
+
+      expect(result.success).toBe(false);
+      expect(result.shouldRetry).toBe(false);
+      assertStepFailure(result, "No download source available");
+    });
+  });
+
+  describe("Configuration", () => {
+    test("should accept undefined config as valid", () => {
+      const step = new DownloadStep();
+      expect(() => step.validateConfig(undefined)).not.toThrow();
+    });
+
+    test("should accept object config as valid", () => {
+      const step = new DownloadStep();
+      expect(() => step.validateConfig({ pollInterval: 1000, timeout: 60000 })).not.toThrow();
+    });
+
+    test("should throw on non-object config", () => {
+      const step = new DownloadStep();
+      expect(() => step.validateConfig("invalid")).toThrow("DownloadStep config must be an object");
+      expect(() => step.validateConfig(42)).toThrow("DownloadStep config must be an object");
+      expect(() => step.validateConfig(true)).toThrow("DownloadStep config must be an object");
+    });
+  });
+
+  describe("Skipped Search with TV", () => {
+    // The mock processingItem.findMany does not handle status: { in: [...] } by default.
+    // Override it to support the `in` operator used by the skippedSearch code path.
+    let originalFindMany: any;
+
+    beforeEach(() => {
+      originalFindMany = mockPrisma.processingItem.findMany;
+      mockPrisma.processingItem.findMany = mock(
+        async ({ where, select }: { where?: any; select?: any } = {}) => {
+          const store = mockPrisma._stores.processingItem as Map<string, any>;
+          let results = Array.from(store.values());
+          if (!where) return results;
+
+          results = results.filter((v: any) =>
+            Object.keys(where).every((key: string) => {
+              if (key === "requestId") {
+                if (where.requestId?.in) return where.requestId.in.includes(v.requestId);
+                return v.requestId === where.requestId;
+              }
+              if (key === "status") {
+                if (where.status?.in) return where.status.in.includes(v.status);
+                if (where.status?.notIn) return !where.status.notIn.includes(v.status);
+                return v.status === where.status;
+              }
+              if (key === "type") return v.type === where.type;
+              return v[key] === where[key];
+            })
+          );
+
+          if (select) {
+            results = results.map((r: any) => {
+              const selected: any = {};
+              Object.keys(select).forEach((k) => {
+                if (select[k]) selected[k] = r[k];
+              });
+              return selected;
+            });
+          }
+
+          return results;
+        }
+      );
+    });
+
+    afterEach(() => {
+      mockPrisma.processingItem.findMany = originalFindMany;
+    });
+
+    test("should handle skippedSearch flag with downloaded episodes", async () => {
+      const request = await createTestRequest({
+        createExecution: true,
+        type: MediaType.TV,
+        tmdbId: TV_SHOWS.BREAKING_BAD.tmdbId,
+        title: TV_SHOWS.BREAKING_BAD.title,
+        year: TV_SHOWS.BREAKING_BAD.year,
+        requestedSeasons: [1],
+        targets: TARGETS.SINGLE_1080P_SERVER,
+      });
+
+      // Create processingItem records that are already downloaded
+      await mockPrisma.processingItem.create({
+        data: {
+          id: "ep-1",
+          requestId: request.id,
+          type: "EPISODE",
+          season: 1,
+          episode: 1,
+          status: ProcessingStatus.DOWNLOADED,
+          sourceFilePath: "/downloads/Breaking.Bad.S01E01.mkv",
+        },
+      });
+
+      await mockPrisma.processingItem.create({
+        data: {
+          id: "ep-2",
+          requestId: request.id,
+          type: "EPISODE",
+          season: 1,
+          episode: 2,
+          status: ProcessingStatus.DOWNLOADED,
+          sourceFilePath: "/downloads/Breaking.Bad.S01E02.mkv",
+        },
+      });
+
+      const context = new ContextBuilder()
+        .forTvShow(
+          TV_SHOWS.BREAKING_BAD.title,
+          TV_SHOWS.BREAKING_BAD.year,
+          TV_SHOWS.BREAKING_BAD.tmdbId,
+          [1]
+        )
+        .withRequestId(request.id)
+        .withTargets(TARGETS.SINGLE_1080P_SERVER)
+        .withSearchResult({ skippedSearch: true } as any)
+        .build();
+
+      const step = new DownloadStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+
+      const downloadData = result.data?.download as Record<string, unknown>;
+      expect(downloadData.episodesQueued).toBe(true);
+      expect(downloadData.queuedCount).toBe(2);
+
+      // Should NOT have created any new downloads
+      expect(mockDownloadManager.createDownload).not.toHaveBeenCalled();
+    });
+
+    test("should fail when skippedSearch is set but no downloaded episodes exist", async () => {
+      const request = await createTestRequest({
+        createExecution: true,
+        type: MediaType.TV,
+        tmdbId: TV_SHOWS.BREAKING_BAD.tmdbId,
+        title: TV_SHOWS.BREAKING_BAD.title,
+        year: TV_SHOWS.BREAKING_BAD.year,
+        requestedSeasons: [1],
+        targets: TARGETS.SINGLE_1080P_SERVER,
+      });
+
+      const context = new ContextBuilder()
+        .forTvShow(
+          TV_SHOWS.BREAKING_BAD.title,
+          TV_SHOWS.BREAKING_BAD.year,
+          TV_SHOWS.BREAKING_BAD.tmdbId,
+          [1]
+        )
+        .withRequestId(request.id)
+        .withTargets(TARGETS.SINGLE_1080P_SERVER)
+        .withSearchResult({ skippedSearch: true } as any)
+        .build();
+
+      const step = new DownloadStep();
+      const result = await step.execute(context, {});
+
+      expect(result.success).toBe(false);
+      expect(result.shouldRetry).toBe(false);
+      assertStepFailure(result, "No downloaded episodes found");
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/steps/EncodeStep.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/steps/EncodeStep.test.ts
@@ -1,0 +1,331 @@
+/**
+ * EncodeStep Unit Tests
+ *
+ * Tests encoding step behavior in isolation without real encoder calls
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createMockPrisma } from "../../../../__tests__/setup.js";
+
+// Mock Prisma client to prevent database access
+const mockPrisma = createMockPrisma();
+
+// Add findFirst for encoderAssignment (not in default mock)
+mockPrisma.encoderAssignment.findFirst = mock(async () => null);
+
+// Track what findUnique should return for encoder assignments
+// Override default since EncodeStep uses where.id but the mock expects where.jobId
+let mockAssignmentStatus: any = null;
+mockPrisma.encoderAssignment.findUnique = mock(async () => mockAssignmentStatus);
+
+mock.module("../../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+// Mock encoder dispatch service
+const mockEncoderService = {
+  queueEncodingJob: mock(async () => ({
+    id: "test-assignment-id",
+    jobId: "test-job-id",
+    status: "PENDING",
+    progress: 0,
+    outputPath: null,
+    outputSize: null,
+    compressionRatio: null,
+    error: null,
+    speed: null,
+    eta: null,
+    assignedAt: new Date(),
+    completedAt: null,
+  })),
+};
+
+mock.module("../../../encoderDispatch.js", () => ({
+  getEncoderDispatchService: () => mockEncoderService,
+}));
+
+// Mock pipeline orchestrator
+const mockOrchestrator = {
+  transitionStatus: mock(async () => ({})),
+  updateProgress: mock(async () => ({})),
+};
+
+mock.module("../../PipelineOrchestrator.js", () => ({
+  pipelineOrchestrator: mockOrchestrator,
+}));
+
+// Import AFTER all mock.module calls
+import { EncodeStep } from "../../steps/EncodeStep.js";
+import { assertStepData, assertStepFailure, assertStepSuccess } from "../test-utils/assertions.js";
+import { ContextBuilder } from "../test-utils/context-builder.js";
+
+// Store original Bun.file for restoration
+const originalBunFile = Bun.file.bind(Bun);
+let mockFileExists = true;
+
+describe("EncodeStep", () => {
+  beforeEach(() => {
+    mockFileExists = true;
+    mockAssignmentStatus = null;
+
+    // Mock Bun.file().exists() to control file existence checks
+    (Bun as any).file = (path: string) => ({
+      exists: async () => mockFileExists,
+      name: path,
+    });
+  });
+
+  afterEach(() => {
+    (Bun as any).file = originalBunFile;
+    mockPrisma._clear();
+    mockEncoderService.queueEncodingJob.mockClear();
+    mockOrchestrator.transitionStatus.mockClear();
+    mockOrchestrator.updateProgress.mockClear();
+  });
+
+  describe("Config Validation", () => {
+    test("should accept undefined config", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig(undefined)).not.toThrow();
+    });
+
+    test("should accept null config", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig(null)).not.toThrow();
+    });
+
+    test("should throw on non-object config", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig("invalid")).toThrow("EncodeStep config must be an object");
+      expect(() => step.validateConfig(42)).toThrow("EncodeStep config must be an object");
+      expect(() => step.validateConfig(true)).toThrow("EncodeStep config must be an object");
+    });
+
+    test("should accept valid CRF values (0-51)", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ crf: 0 })).not.toThrow();
+      expect(() => step.validateConfig({ crf: 28 })).not.toThrow();
+      expect(() => step.validateConfig({ crf: 51 })).not.toThrow();
+    });
+
+    test("should throw on invalid CRF values", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ crf: -1 })).toThrow(
+        "crf must be a number between 0 and 51"
+      );
+      expect(() => step.validateConfig({ crf: 52 })).toThrow(
+        "crf must be a number between 0 and 51"
+      );
+      expect(() => step.validateConfig({ crf: "high" })).toThrow(
+        "crf must be a number between 0 and 51"
+      );
+    });
+
+    test("should accept valid preset values", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ preset: "fast" })).not.toThrow();
+      expect(() => step.validateConfig({ preset: "medium" })).not.toThrow();
+      expect(() => step.validateConfig({ preset: "slow" })).not.toThrow();
+    });
+
+    test("should throw on invalid preset", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ preset: "ultrafast" })).toThrow(
+        "preset must be one of: fast, medium, slow"
+      );
+      expect(() => step.validateConfig({ preset: "veryslow" })).toThrow(
+        "preset must be one of: fast, medium, slow"
+      );
+    });
+
+    test("should accept valid maxResolution values", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ maxResolution: "480p" })).not.toThrow();
+      expect(() => step.validateConfig({ maxResolution: "720p" })).not.toThrow();
+      expect(() => step.validateConfig({ maxResolution: "1080p" })).not.toThrow();
+      expect(() => step.validateConfig({ maxResolution: "2160p" })).not.toThrow();
+    });
+
+    test("should throw on invalid maxResolution", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ maxResolution: "4K" })).toThrow(
+        "maxResolution must be one of: 480p, 720p, 1080p, 2160p"
+      );
+      expect(() => step.validateConfig({ maxResolution: "360p" })).toThrow(
+        "maxResolution must be one of: 480p, 720p, 1080p, 2160p"
+      );
+    });
+
+    test("should accept valid hwAccel values", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ hwAccel: "NONE" })).not.toThrow();
+      expect(() => step.validateConfig({ hwAccel: "QSV" })).not.toThrow();
+      expect(() => step.validateConfig({ hwAccel: "NVENC" })).not.toThrow();
+      expect(() => step.validateConfig({ hwAccel: "VAAPI" })).not.toThrow();
+      expect(() => step.validateConfig({ hwAccel: "AMF" })).not.toThrow();
+      expect(() => step.validateConfig({ hwAccel: "VIDEOTOOLBOX" })).not.toThrow();
+    });
+
+    test("should throw on invalid hwAccel", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ hwAccel: "CUDA" })).toThrow(
+        "hwAccel must be one of: NONE, QSV, NVENC, VAAPI, AMF, VIDEOTOOLBOX"
+      );
+    });
+
+    test("should accept valid subtitlesMode values", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ subtitlesMode: "COPY" })).not.toThrow();
+      expect(() => step.validateConfig({ subtitlesMode: "COPY_TEXT" })).not.toThrow();
+      expect(() => step.validateConfig({ subtitlesMode: "EXTRACT" })).not.toThrow();
+      expect(() => step.validateConfig({ subtitlesMode: "NONE" })).not.toThrow();
+    });
+
+    test("should throw on invalid subtitlesMode", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ subtitlesMode: "BURN" })).toThrow(
+        "subtitlesMode must be one of: COPY, COPY_TEXT, EXTRACT, NONE"
+      );
+    });
+
+    test("should accept valid container values", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ container: "MKV" })).not.toThrow();
+      expect(() => step.validateConfig({ container: "MP4" })).not.toThrow();
+      expect(() => step.validateConfig({ container: "WEBM" })).not.toThrow();
+    });
+
+    test("should throw on invalid container", () => {
+      const step = new EncodeStep();
+      expect(() => step.validateConfig({ container: "AVI" })).toThrow(
+        "container must be one of: MKV, MP4, WEBM"
+      );
+    });
+  });
+
+  describe("Recovery", () => {
+    test("should skip encoding when context already has encodedFiles", async () => {
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("test-request-recovery")
+        .withTargets([{ serverId: "server-1" }])
+        .withEncodeResult({
+          encodedFiles: [
+            {
+              profileId: "default",
+              path: "/encoded/inception.mkv",
+              targetServerIds: ["server-1"],
+              resolution: "1080p",
+              codec: "AV1",
+            },
+          ],
+        })
+        .build();
+
+      const step = new EncodeStep();
+      const result = await step.execute(context, {});
+
+      assertStepSuccess(result);
+      assertStepData(result, "encode");
+
+      const encodeData = result.data?.encode as Record<string, unknown>;
+      const files = encodeData.encodedFiles as Array<Record<string, unknown>>;
+      expect(files.length).toBe(1);
+      expect(files[0].path).toBe("/encoded/inception.mkv");
+
+      // Should NOT have created any encoding job
+      expect(mockEncoderService.queueEncodingJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("No Source File", () => {
+    test("should fail when context has no download.sourceFilePath", async () => {
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("test-request-nosource")
+        .withTargets([{ serverId: "server-1" }])
+        .build();
+
+      const step = new EncodeStep();
+      const result = await step.execute(context, {});
+
+      assertStepFailure(
+        result,
+        "No source file path or episode files available from download step"
+      );
+    });
+
+    test("should fail when source file does not exist on disk", async () => {
+      mockFileExists = false;
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("test-request-nofile")
+        .withTargets([{ serverId: "server-1" }])
+        .withDownloadResult({
+          torrentHash: "abc123",
+          sourceFilePath: "/downloads/nonexistent.mkv",
+        })
+        .build();
+
+      const step = new EncodeStep();
+      const result = await step.execute(context, {});
+
+      assertStepFailure(result, "Source file not found");
+    });
+  });
+
+  describe("Happy Path", () => {
+    test("should create encoding job and return encoded file on completion", async () => {
+      mockFileExists = true;
+
+      // Set up the assignment status to return COMPLETED on first poll
+      mockAssignmentStatus = {
+        id: "test-assignment-id",
+        jobId: "test-job-id",
+        status: "COMPLETED",
+        progress: 100,
+        outputPath: "/downloads/encoded_output.mkv",
+        outputSize: BigInt(2_000_000_000),
+        compressionRatio: 0.4,
+        error: null,
+        speed: null,
+        eta: null,
+      };
+
+      const context = new ContextBuilder()
+        .forMovie("Inception", 2010, 27205)
+        .withRequestId("test-request-happy")
+        .withTargets([{ serverId: "server-1", encodingProfileId: "profile-1" }])
+        .withDownloadResult({
+          torrentHash: "abc123",
+          sourceFilePath: "/downloads/Inception.2010.1080p.BluRay/movie.mkv",
+        })
+        .build();
+
+      const step = new EncodeStep();
+      const result = await step.execute(context, {
+        pollInterval: 1,
+        timeout: 5000,
+      });
+
+      assertStepSuccess(result);
+      assertStepData(result, "encode");
+
+      const encodeData = result.data?.encode as Record<string, unknown>;
+      const files = encodeData.encodedFiles as Array<Record<string, unknown>>;
+      expect(files.length).toBe(1);
+      expect(files[0].path).toBe("/downloads/encoded_output.mkv");
+      expect(files[0].targetServerIds).toEqual(["server-1"]);
+      expect(files[0].codec).toBe("AV1");
+      expect(files[0].resolution).toBe("1080p");
+      expect(files[0].profileId).toBe("profile-1");
+      expect(files[0].size).toBe(2_000_000_000);
+      expect(files[0].compressionRatio).toBe(0.4);
+
+      // Verify encoder service was called
+      expect(mockEncoderService.queueEncodingJob).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/server/src/services/pipeline/__tests__/steps/NotificationStep.test.ts
+++ b/packages/server/src/services/pipeline/__tests__/steps/NotificationStep.test.ts
@@ -1,0 +1,317 @@
+/**
+ * NotificationStep Unit Tests
+ *
+ * Tests notification step behavior in isolation without real notification providers
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { MediaType } from "@prisma/client";
+import { createMockPrisma } from "../../../../__tests__/setup.js";
+
+// Mock Prisma client to prevent database access
+const mockPrisma = createMockPrisma();
+mock.module("../../../../db/client.js", () => ({
+  prisma: mockPrisma,
+  db: mockPrisma,
+}));
+
+// Mock notification dispatcher
+let mockDispatchFn: any = mock(async () => [] as any[]);
+
+mock.module("../../../notifications/NotificationDispatcher.js", () => ({
+  getNotificationDispatcher: () => ({
+    dispatch: mockDispatchFn,
+  }),
+}));
+
+import { NotificationStep } from "../../steps/NotificationStep.js";
+import { ContextBuilder } from "../test-utils/context-builder.js";
+
+function createBaseContext() {
+  return new ContextBuilder()
+    .forMovie("Inception", 2010, 27205)
+    .withRequestId("test-request-1")
+    .withTargets([{ serverId: "server-1" }])
+    .build();
+}
+
+describe("NotificationStep", () => {
+  let step: NotificationStep;
+
+  beforeEach(() => {
+    step = new NotificationStep();
+    mockDispatchFn = mock(async () => []);
+  });
+
+  afterEach(() => {
+    mockPrisma._clear();
+  });
+
+  describe("Config Validation", () => {
+    test("should throw when config is null", () => {
+      expect(() => step.validateConfig(null)).toThrow("NotificationStep config must be an object");
+    });
+
+    test("should throw when config is undefined", () => {
+      expect(() => step.validateConfig(undefined)).toThrow(
+        "NotificationStep config must be an object"
+      );
+    });
+
+    test("should throw when config has no event", () => {
+      expect(() => step.validateConfig({})).toThrow(
+        "NotificationStep config must have an 'event' string"
+      );
+    });
+
+    test("should throw when event is empty string", () => {
+      expect(() => step.validateConfig({ event: "" })).toThrow(
+        "NotificationStep config must have an 'event' string"
+      );
+    });
+
+    test("should throw when event is not a string", () => {
+      expect(() => step.validateConfig({ event: 123 })).toThrow(
+        "NotificationStep config must have an 'event' string"
+      );
+    });
+
+    test("should pass with valid config", () => {
+      expect(() => step.validateConfig({ event: "request.completed" })).not.toThrow();
+    });
+  });
+
+  describe("Successful Dispatch", () => {
+    test("should return success with all providers succeeding", async () => {
+      mockDispatchFn = mock(async () => [
+        { success: true, provider: "DISCORD" },
+        { success: true, provider: "WEBHOOK" },
+      ]);
+
+      const context = createBaseContext();
+      const result = await step.execute(context, { event: "request.completed" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.sent).toBe(true);
+      expect(result.data?.providers).toEqual(["DISCORD", "WEBHOOK"]);
+      expect(result.data?.errors).toBeUndefined();
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe("All Providers Fail", () => {
+    test("should return success=true when continueOnError defaults to true", async () => {
+      mockDispatchFn = mock(async () => [
+        { success: false, provider: "DISCORD", error: "Connection refused" },
+        { success: false, provider: "WEBHOOK", error: "Timeout" },
+      ]);
+
+      const context = createBaseContext();
+      const result = await step.execute(context, { event: "request.completed" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.sent).toBe(false);
+      expect(result.data?.providers).toEqual([]);
+      expect(result.data?.errors).toEqual([
+        { provider: "DISCORD", error: "Connection refused" },
+        { provider: "WEBHOOK", error: "Timeout" },
+      ]);
+      expect(result.error).toBeUndefined();
+    });
+
+    test("should return success=false when continueOnError is explicitly false", async () => {
+      mockDispatchFn = mock(async () => [
+        { success: false, provider: "DISCORD", error: "Connection refused" },
+        { success: false, provider: "WEBHOOK", error: "Timeout" },
+      ]);
+
+      const context = createBaseContext();
+      const result = await step.execute(context, {
+        event: "request.completed",
+        continueOnError: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.data?.sent).toBe(false);
+      expect(result.error).toBe("All notifications failed: Connection refused, Timeout");
+    });
+  });
+
+  describe("Partial Provider Failure", () => {
+    test("should return success=true with partial results", async () => {
+      mockDispatchFn = mock(async () => [
+        { success: true, provider: "DISCORD" },
+        { success: false, provider: "WEBHOOK", error: "Timeout" },
+      ]);
+
+      const context = createBaseContext();
+      const result = await step.execute(context, { event: "request.completed" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.sent).toBe(true);
+      expect(result.data?.providers).toEqual(["DISCORD"]);
+      expect(result.data?.errors).toEqual([{ provider: "WEBHOOK", error: "Timeout" }]);
+    });
+  });
+
+  describe("Dispatcher Exception", () => {
+    test("should return success=true when continueOnError defaults to true", async () => {
+      mockDispatchFn = mock(async () => {
+        throw new Error("Network error");
+      });
+
+      const context = createBaseContext();
+      const result = await step.execute(context, { event: "request.completed" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.sent).toBe(false);
+      expect(result.data?.error).toBe("Network error");
+    });
+
+    test("should return success=false when continueOnError is false", async () => {
+      mockDispatchFn = mock(async () => {
+        throw new Error("Network error");
+      });
+
+      const context = createBaseContext();
+      const result = await step.execute(context, {
+        event: "request.completed",
+        continueOnError: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Network error");
+      expect(result.data?.sent).toBe(false);
+      expect(result.data?.error).toBe("Network error");
+    });
+
+    test("should handle non-Error exceptions", async () => {
+      mockDispatchFn = mock(async () => {
+        throw "string error";
+      });
+
+      const context = createBaseContext();
+      const result = await step.execute(context, { event: "request.completed" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.sent).toBe(false);
+      expect(result.data?.error).toBe("string error");
+    });
+  });
+
+  describe("Context Data Passing", () => {
+    test("should pass only title, year, tmdbId when includeContext is false", async () => {
+      let capturedOptions: any;
+      mockDispatchFn = mock(async (options: any) => {
+        capturedOptions = options;
+        return [{ success: true, provider: "DISCORD" }];
+      });
+
+      const context = createBaseContext();
+      context.search = {
+        selectedRelease: {
+          title: "Inception.2010.1080p",
+          size: 5000,
+          seeders: 100,
+          indexer: "test",
+        },
+      };
+
+      await step.execute(context, { event: "request.completed", includeContext: false });
+
+      expect(capturedOptions.data).toEqual({
+        title: "Inception",
+        year: 2010,
+        tmdbId: 27205,
+      });
+      expect(capturedOptions.data.search).toBeUndefined();
+    });
+
+    test("should pass full context when includeContext is true", async () => {
+      let capturedOptions: any;
+      mockDispatchFn = mock(async (options: any) => {
+        capturedOptions = options;
+        return [{ success: true, provider: "DISCORD" }];
+      });
+
+      const context = createBaseContext();
+      context.search = {
+        selectedRelease: {
+          title: "Inception.2010.1080p",
+          size: 5000,
+          seeders: 100,
+          indexer: "test",
+        },
+      };
+      context.download = { torrentHash: "abc123" };
+
+      await step.execute(context, { event: "request.completed", includeContext: true });
+
+      expect(capturedOptions.data.title).toBe("Inception");
+      expect(capturedOptions.data.year).toBe(2010);
+      expect(capturedOptions.data.tmdbId).toBe(27205);
+      expect(capturedOptions.data.search).toBeDefined();
+      expect(capturedOptions.data.download).toBeDefined();
+      expect(capturedOptions.data.download.torrentHash).toBe("abc123");
+    });
+
+    test("should pass event, requestId, and mediaType to dispatcher", async () => {
+      let capturedOptions: any;
+      mockDispatchFn = mock(async (options: any) => {
+        capturedOptions = options;
+        return [];
+      });
+
+      const context = createBaseContext();
+      await step.execute(context, { event: "request.started" });
+
+      expect(capturedOptions.event).toBe("request.started");
+      expect(capturedOptions.requestId).toBe("test-request-1");
+      expect(capturedOptions.mediaType).toBe(MediaType.MOVIE);
+    });
+  });
+
+  describe("Failed Provider Error Messages", () => {
+    test("should use 'Unknown error' when provider error is undefined", async () => {
+      mockDispatchFn = mock(async () => [
+        { success: false, provider: "DISCORD", error: undefined },
+      ]);
+
+      const context = createBaseContext();
+      const result = await step.execute(context, { event: "request.completed" });
+
+      expect(result.data?.errors).toEqual([{ provider: "DISCORD", error: "Unknown error" }]);
+    });
+  });
+
+  describe("Activity Logging", () => {
+    test("should log success activity when providers succeed", async () => {
+      mockDispatchFn = mock(async () => [{ success: true, provider: "DISCORD" }]);
+
+      const context = createBaseContext();
+      await step.execute(context, { event: "request.completed" });
+
+      expect(mockPrisma.activityLog.create).toHaveBeenCalled();
+    });
+
+    test("should log warning activity when providers fail", async () => {
+      mockDispatchFn = mock(async () => [{ success: false, provider: "DISCORD", error: "Failed" }]);
+
+      const context = createBaseContext();
+      await step.execute(context, { event: "request.completed" });
+
+      expect(mockPrisma.activityLog.create).toHaveBeenCalled();
+    });
+
+    test("should log error activity when dispatcher throws", async () => {
+      mockDispatchFn = mock(async () => {
+        throw new Error("Dispatcher crash");
+      });
+
+      const context = createBaseContext();
+      await step.execute(context, { event: "request.completed" });
+
+      expect(mockPrisma.activityLog.create).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive test coverage for the requests router and circuit breaker service. The test suites validate the core functionality of media request management, including creation, cancellation, retry logic, and quality acceptance workflows. Additionally, circuit breaker state transitions and failure handling are thoroughly tested.

### Changes

**New Test Files:**
- `packages/server/src/__tests__/routers/requests.test.ts` - 915 lines of tests covering:
  - Movie/TV request creation with pipeline orchestration
  - Request cancellation and deletion
  - Request and episode retry logic with pipeline execution management
  - Episode-specific operations (cancel, retry, re-encode, re-deliver)
  - Quality acceptance workflows for alternative releases
  - Discovered release override and approval flows
  - Item-level operations delegating to orchestrator

- `packages/server/src/services/pipeline/__tests__/CircuitBreakerService.test.ts` - 327 lines of tests covering:
  - Circuit breaker state transitions (CLOSED → OPEN → HALF_OPEN → CLOSED)
  - Failure threshold and success threshold logic
  - Cooldown period management
  - State queries and breaker information retrieval
  - Full lifecycle state machine validation

### Test Infrastructure

Both test suites include:
- Comprehensive mock setup for Prisma database operations
- Mock implementations of pipeline orchestrator, executor, and related services
- Helper functions for seeding test data (requests, processing items, templates)
- Proper cleanup between tests using `beforeEach`/`afterEach` hooks

### Key Test Coverage

**Requests Router:**
- ✅ Request creation with default pipeline templates
- ✅ Cascading cancellation of processing items and encoding jobs
- ✅ Retry logic with pipeline execution fallback to default templates
- ✅ Episode-level operations with proper validation
- ✅ Quality acceptance with alternative release selection
- ✅ Discovered release override with cooldown management
- ✅ Known issue: `cancelEpisode` bypasses orchestrator validation (documented in tests)

**Circuit Breaker:**
- ✅ State machine correctness across all transitions
- ✅ Failure threshold triggering circuit open
- ✅ Success threshold for recovery from HALF_OPEN
- ✅ Cooldown period enforcement
- ✅ Immediate reopening on HALF_OPEN failure

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Checklist

- [ ] I have run `bun run lint` and fixed any errors
- [ ] I have run `bun run typecheck` and there are no type errors
- [ ] I have run `bun run build` and it completes successfully
- [ ] I have tested my changes locally
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Notes

The test suites document the current behavior including a known issue in `cancelEpisode` where it bypasses orchestrator validation, allowing cancellation of terminal states (COMPLETED/FAILED). This is marked as a BUG in the tests and should be addressed in a follow-up PR.

https://claude.ai/code/session_01A8iQv8f8SSNzVMmE5q1RBN