### PR TITLE
fix(mcp): fix playback_reporting response field mapping

### DIFF
--- a/packages/server/src/mcp/tools/watchHistory.ts
+++ b/packages/server/src/mcp/tools/watchHistory.ts
@@ -18,14 +18,14 @@ interface WatchedItem {
 }
 
 interface PlaybackReportItem {
-  Date: string;
-  RowId: number;
-  Name: string;
-  ItemId: string;
-  ItemType: string;
-  Duration: number;
-  UserId: string;
-  RemoteAddress: string;
+  date: string;
+  time: string;
+  user_id: string;
+  item_name: string;
+  item_id: string;
+  item_type: string;
+  duration: number;
+  remote_address: string;
 }
 
 function decryptApiKey(value: string | null | undefined): string | null {
@@ -75,20 +75,20 @@ async function fetchEmbyPlaybackReporting(
     >();
 
     for (const entry of data) {
-      const existing = itemMap.get(entry.ItemId);
+      const existing = itemMap.get(entry.item_id);
       if (existing) {
         existing.playCount += 1;
-        existing.totalDuration += entry.Duration;
-        if (entry.Date > existing.lastPlayDate) {
-          existing.lastPlayDate = entry.Date;
+        existing.totalDuration += entry.duration;
+        if (entry.date > existing.lastPlayDate) {
+          existing.lastPlayDate = entry.date;
         }
       } else {
-        itemMap.set(entry.ItemId, {
-          name: entry.Name,
-          itemType: entry.ItemType,
+        itemMap.set(entry.item_id, {
+          name: entry.item_name,
+          itemType: entry.item_type,
           playCount: 1,
-          totalDuration: entry.Duration,
-          lastPlayDate: entry.Date,
+          totalDuration: entry.duration,
+          lastPlayDate: entry.date,
         });
       }
     }


### PR DESCRIPTION
Plugin returns lowercase snake_case fields (date, item_name, item_id, item_type, duration) not PascalCase. All field accesses were reading undefined, producing empty results.

https://claude.ai/code/session_01448wJXVdPi7Qh5SYJevSwM

## Description

<!-- Briefly describe the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Checklist

- [ ] I have run `bun run lint` and fixed any errors
- [ ] I have run `bun run typecheck` and there are no type errors
- [ ] I have run `bun run build` and it completes successfully
- [ ] I have tested my changes locally
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
